### PR TITLE
Update blender.py

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -42,7 +42,7 @@ async def main():
         ctx.log("no more frames to render")
 
     async with Engine(
-        package=package, max_workers=10, budget=10.0, timeout=timedelta(minutes=15), subnet_tag="testnet"
+        package=package, max_workers=2, budget=10.0, timeout=timedelta(minutes=15), subnet_tag="testnet"
     ) as engine:
 
         async for progress in engine.map(worker, [Task(data=frame) for frame in range(0, 60, 10)]):


### PR DESCRIPTION
changing number of max_workers to default "2" to make it less possible that we will have an effect of long queue on release and people loosing patience