### PR TITLE
Limit worker count based on max_workers

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -42,7 +42,11 @@ async def main():
         ctx.log("no more frames to render")
 
     async with Engine(
-        package=package, max_workers=10, budget=10.0, timeout=timedelta(minutes=15), subnet_tag="testnet"
+        package=package,
+        max_workers=10,
+        budget=10.0,
+        timeout=timedelta(minutes=15),
+        subnet_tag="testnet",
     ) as engine:
 
         async for progress in engine.map(worker, [Task(data=frame) for frame in range(0, 60, 10)]):

--- a/yapapi/runner/__init__.py
+++ b/yapapi/runner/__init__.py
@@ -289,7 +289,7 @@ class Engine(AsyncContextManager):
         async def worker_starter():
             while True:
                 await asyncio.sleep(2)
-                if offer_buffer:
+                if offer_buffer and len(workers) < self._conf.max_workers:
                     provider_id, b = random.choice(list(offer_buffer.items()))
                     del offer_buffer[provider_id]
                     try:


### PR DESCRIPTION
Previously, the parameter `max_workers` on `Engine` was not being used. This adds a condition to limit the number of concurrent workers based on that value.