### PR TITLE
Exit early on task timeout

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -43,12 +43,15 @@ async def main():
 
     # iterator over the frame indices that we want to render
     frames: range = range(0, 60, 10)
+    # TODO make this dynamic, e.g. depending on the size of files to transfer
+    # worst-case time overhead for initialization, e.g. negotiation, file transfer etc.
+    init_overhead: timedelta = timedelta(minutes=3)
 
     async with Engine(
         package=package,
         max_workers=10,
         budget=10.0,
-        timeout=timedelta(minutes=len(frames) * 2),
+        timeout=init_overhead + timedelta(minutes=len(frames) * 2),
         subnet_tag="testnet",
     ) as engine:
 

--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -45,7 +45,7 @@ async def main():
         package=package,
         max_workers=10,
         budget=10.0,
-        timeout=timedelta(minutes=15),
+        timeout=timedelta(minutes=5),
         subnet_tag="testnet",
     ) as engine:
 

--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -41,16 +41,18 @@ async def main():
 
         ctx.log("no more frames to render")
 
+    # iterator over the frame indices that we want to render
+    frames: range = range(0, 60, 10)
+
     async with Engine(
         package=package,
         max_workers=10,
         budget=10.0,
-        timeout=timedelta(minutes=5),
+        timeout=timedelta(minutes=len(frames) * 2),
         subnet_tag="testnet",
     ) as engine:
 
-        async for progress in engine.map(worker, [Task(data=frame) for frame in range(0, 60, 10)]):
-
+        async for progress in engine.map(worker, [Task(data=frame) for frame in frames]):
             print("progress=", progress)
 
 

--- a/yapapi/runner/__init__.py
+++ b/yapapi/runner/__init__.py
@@ -338,6 +338,9 @@ class Engine(AsyncContextManager):
                 or not work_queue.empty()
                 or tasks_processed["s"] > tasks_processed["c"]
             ):
+                if datetime.now(timezone.utc) > self._expires:
+                    raise TimeoutError(f"task timeout exceeded. timeout={self._conf.timeout}")
+
                 done, pending = await asyncio.wait(
                     services.union(workers), timeout=10, return_when=asyncio.FIRST_COMPLETED
                 )


### PR DESCRIPTION
Adds a check which terminates the program once the timeout for the whole task is exceeded (as specified via `timeout` parameter to `Engine` constructor).
Also changes the default timeout value for the Blender example (`examples/blender/blender.py`) to 5 minutes.