### PR TITLE
Handle exceptions raised in `score_offers`

### DIFF
--- a/tests/props/test_from_props.py
+++ b/tests/props/test_from_props.py
@@ -1,0 +1,85 @@
+"""Unit tests for `yapapi.props.base.Model.from_props` method"""
+
+import pytest
+
+from yapapi.props import com, InvalidPropertiesError
+
+
+@pytest.mark.parametrize(
+    "props, error_msg",
+    [
+        (
+            {
+                "golem.com.pricing.model": "linear",
+                "golem.com.pricing.model.linear.coeffs": [0.001, 0.002, 0.0],
+                "golem.com.usage.vector": ["golem.usage.cpu_sec", "golem.usage.duration_sec"],
+                "golem.com.scheme": "payu",
+            },
+            None,
+        ),
+        (
+            {
+                "golem.com.pricing.model": "linear",
+                "golem.com.pricing.model.linear.coeffs": [0.001, 0.002, 0.0],
+                "golem.com.usage.vector": ["golem.usage.cpu_sec", "golem.usage.duration_sec"],
+                # "golem.com.scheme": "payu",
+            },
+            "missing 1 required positional argument: 'scheme'",
+        ),
+        (
+            {
+                "golem.com.pricing.model": "linear",
+                # "golem.com.pricing.model.linear.coeffs": [0.001, 0.002, 0.0],
+                "golem.com.usage.vector": ["golem.usage.cpu_sec", "golem.usage.duration_sec"],
+                "golem.com.scheme": "payu",
+            },
+            "Missing key: 'golem.com.pricing.model.linear.coeffs'",
+        ),
+        (
+            {
+                "golem.com.pricing.model": "linear",
+                "golem.com.pricing.model.linear.coeffs": [],
+                "golem.com.usage.vector": ["golem.usage.cpu_sec", "golem.usage.duration_sec"],
+                "golem.com.scheme": "payu",
+            },
+            "pop from empty list",
+        ),
+        (
+            {
+                "golem.com.pricing.model": "linear",
+                "golem.com.pricing.model.linear.coeffs": [0.001, 0.002, 0.0],
+                "golem.com.usage.vector": ["golem.usage.cpu_sec"],
+                "golem.com.scheme": "payu",
+            },
+            "list index out of range",
+        ),
+        (
+            {
+                "golem.com.pricing.model": "linear",
+                "golem.com.pricing.model.linear.coeffs": ["spam", 0.002, 0.0],
+                "golem.com.usage.vector": ["golem.usage.cpu_sec", "golem.usage.duration_sec"],
+                "golem.com.scheme": "payu",
+            },
+            "could not convert string to float",
+        ),
+        (
+            {
+                "golem.com.pricing.model": "linear",
+                "golem.com.pricing.model.linear.coeffs": ["spam", 0.002, 0.0],
+                "golem.com.usage.vector": "not a vector",
+                "golem.com.scheme": "payu",
+            },
+            "Error when decoding 'not a vector'",
+        ),
+    ],
+)
+def test_from_props(props, error_msg):
+    """Check whether `from_props(props)` raises errors for invalid `props`."""
+
+    try:
+        com.ComLinear.from_props(props)
+    except InvalidPropertiesError as exc:
+        if error_msg is not None:
+            assert error_msg in str(exc)
+        else:
+            assert False, exc

--- a/yapapi/props/__init__.py
+++ b/yapapi/props/__init__.py
@@ -1,4 +1,4 @@
-from .base import Model
+from .base import InvalidPropertiesError, Model
 from dataclasses import dataclass, field
 from typing import Optional
 from decimal import Decimal

--- a/yapapi/runner/__init__.py
+++ b/yapapi/runner/__init__.py
@@ -37,6 +37,7 @@ from . import events
 from .utils import AsyncWrapper
 from .. import rest
 from ..props import com, Activity, Identification, IdentificationKeys
+from ..props.base import InvalidPropertiesError
 from ..props.builder import DemandBuilder
 from ..storage import gftp
 
@@ -86,10 +87,8 @@ class DummyMS(MarketStrategy, object):
         self._activity = Activity.from_props(demand.props)
 
     async def score_offer(self, offer: rest.market.OfferProposal) -> float:
-        try:
-            linear: com.ComLinear = com.ComLinear.from_props(offer.props)
-        except Exception:
-            return SCORE_REJECTED
+
+        linear: com.ComLinear = com.ComLinear.from_props(offer.props)
 
         if linear.scheme != com.BillingScheme.PAYU:
             return SCORE_REJECTED
@@ -114,10 +113,8 @@ class LeastExpensiveLinearPayuMS(MarketStrategy, object):
         demand.ensure(f"({com.PRICE_MODEL}={com.PriceModel.LINEAR.value})")
 
     async def score_offer(self, offer: rest.market.OfferProposal) -> float:
-        try:
-            linear: com.ComLinear = com.ComLinear.from_props(offer.props)
-        except Exception:
-            return SCORE_REJECTED
+
+        linear: com.ComLinear = com.ComLinear.from_props(offer.props)
 
         if linear.scheme != com.BillingScheme.PAYU:
             return SCORE_REJECTED
@@ -319,7 +316,11 @@ class Engine(AsyncContextManager):
                     raise
                 async for proposal in proposals:
                     emit(events.ProposalReceived(prop_id=proposal.id, provider_id=proposal.issuer))
-                    score = await strategy.score_offer(proposal)
+                    try:
+                        score = await strategy.score_offer(proposal)
+                    except InvalidPropertiesError as err:
+                        emit(events.ProposalRejected(prop_id=proposal.id, reason=str(err)))
+                        continue
                     if score < SCORE_NEUTRAL:
                         with contextlib.suppress(Exception):
                             await proposal.reject()

--- a/yapapi/runner/events.py
+++ b/yapapi/runner/events.py
@@ -57,7 +57,7 @@ class ProposalReceived(ProposalEvent):
 
 @dataclass
 class ProposalRejected(ProposalEvent):
-    pass
+    reason: Optional[str]
 
 
 @dataclass


### PR DESCRIPTION
Resolves #42 

* A new exception type `InvalidPropertiesError` is raised if parsing properties fails in `Model.from_props()`
* This exception is caught in `find_offers()` task in `Engine.map()`, and results in the offer being rejected.