### PR TITLE
ugh... fix the `pydoc-markdown` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.2.1-alpha.1"
+version = "0.2.1-alpha.2"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>"]
 license = "LGPL-3.0-or-later"
@@ -33,7 +33,6 @@ jsonrpc-base = "^1.0.3"
 
 ya-aioclient = "^0.1.1"
 toml = "^0.10.1"
-pydoc-markdown = "^3.5.0"
 
 
 [tool.poetry.extras]
@@ -49,6 +48,7 @@ mypy = "^0.782"
 liccheck = "^0.4.7"
 poethepoet = "^0.8.0"
 pytest-cov = "^2.10.1"
+pydoc-markdown = "^3.5.0"
 
 [tool.portray]
 


### PR DESCRIPTION
(`pydoc-markdown` had been inadvertently included as a non-dev dependency)

plus, bump the prerelease version