### PR TITLE
Remove `examples/blender/run-blender.sh`

### DIFF
--- a/examples/blender/run-blender.sh
+++ b/examples/blender/run-blender.sh
@@ -1,4 +1,0 @@
-#! /bin/bash
-
-cd /golem/work
-python3 /golem/entrypoints/render_entrypoint.py


### PR DESCRIPTION
The script `examples/blender/run-blender.sh` is not used for anything.

Moreover, the blender example contains the line https://github.com/golemfactory/yapapi/blob/b4b80ca63ef0e8a84d8c5c7b7493eef6aba88acd/examples/blender/blender.py#L47 which may lead someone to think that it's `examples/blender/run-blender.sh` that is somhow run on the providers.