### PR TITLE
remove the default subnet from the example code

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -16,7 +16,7 @@ sys.path.append(str(parent_directory))
 import utils  # noqa
 
 
-async def main(subnet_tag="testnet"):
+async def main(subnet_tag: str):
     package = await vm.repo(
         image_hash="9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
         min_mem_gib=0.5,
@@ -73,7 +73,11 @@ async def main(subnet_tag="testnet"):
     ) as engine:
 
         async for task in engine.map(worker, [Task(data=frame) for frame in frames]):
-            print(f"\033[36;1mTask computed: {task}, result: {task.output}\033[0m")
+            print(
+                f"{utils.TEXT_COLOR_CYAN}"
+                f"Task computed: {task}, result: {task.output}"
+                f"{utils.TEXT_COLOR_DEFAULT}"
+            )
 
 
 if __name__ == "__main__":
@@ -85,6 +89,8 @@ if __name__ == "__main__":
 
     enable_default_logger(level=args.log_level)
     loop = asyncio.get_event_loop()
+    subnet = args.subnet_tag
+    sys.stderr.write(f"Using subnet: {utils.TEXT_COLOR_YELLOW}{subnet}{utils.TEXT_COLOR_DEFAULT}\n")
     task = loop.create_task(main(subnet_tag=args.subnet_tag))
     try:
         asyncio.get_event_loop().run_until_complete(task)

--- a/examples/low-level-api/list-offers.py
+++ b/examples/low-level-api/list-offers.py
@@ -10,7 +10,7 @@ from yapapi.props.builder import DemandBuilder
 from yapapi.rest import Configuration, Market, Activity, Payment  # noqa
 
 
-async def list_offers(conf: Configuration, subnet_tag="testnet"):
+async def list_offers(conf: Configuration, subnet_tag: str):
     async with conf.market() as client:
         market_api = Market(client)
         dbuild = DemandBuilder()
@@ -37,10 +37,14 @@ def main():
 
     parser = utils.build_parser("List offers")
     args = parser.parse_args()
+
+    subnet = args.subnet_tag
+    sys.stderr.write(f"Using subnet: {utils.TEXT_COLOR_YELLOW}{subnet}{utils.TEXT_COLOR_DEFAULT}\n")
+
     enable_default_logger(level=args.log_level)
     try:
         asyncio.get_event_loop().run_until_complete(
-            asyncio.wait_for(list_offers(Configuration(), subnet_tag=args.subnet_tag,), timeout=4,)
+            asyncio.wait_for(list_offers(Configuration(), subnet_tag=subnet,), timeout=4,)
         )
     except TimeoutError:
         pass

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -2,10 +2,20 @@
 import argparse
 import logging
 
+TEXT_COLOR_RED = "\033[31;1m"
+TEXT_COLOR_GREEN = "\033[32;1m"
+TEXT_COLOR_YELLOW = "\033[33;1m"
+TEXT_COLOR_BLUE = "\033[34;1m"
+TEXT_COLOR_MAGENTA = "\033[35;1m"
+TEXT_COLOR_CYAN = "\033[36;1m"
+TEXT_COLOR_WHITE = "\033[37;1m"
+
+TEXT_COLOR_DEFAULT = "\033[0m"
+
 
 def build_parser(description: str):
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("--subnet-tag", default="testnet")
+    parser.add_argument("--subnet-tag", default="devnet-alpha.2")
     parser.add_argument(
         "--debug", dest="log_level", action="store_const", const=logging.DEBUG, default=logging.INFO
     )


### PR DESCRIPTION
(redundant since it's in the parsed command args anyway)

* make `devnet-alpha.2` the default subnet in the examples for alpha.dwa
* add colors to `utils.py` to make the tutorial examples more readable
* add a message displaying the currently used subnet in the beginning of the output

closes: https://github.com/golemfactory/yapapi/issues/61