### PR TITLE
Log with level DEBUG to a log file

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -69,7 +69,7 @@ async def main(subnet_tag="testnet"):
         budget=10.0,
         timeout=init_overhead + timedelta(minutes=len(frames) * 2),
         subnet_tag=subnet_tag,
-        event_emitter=log_summary(),
+        event_emitter=log_summary(log_event_repr),
     ) as engine:
 
         async for task in engine.map(worker, [Task(data=frame) for frame in frames]):
@@ -81,9 +81,10 @@ if __name__ == "__main__":
     import sys
 
     parser = utils.build_parser("Render blender scene")
+    parser.set_defaults(log_file="blender-yapapi.log")
     args = parser.parse_args()
 
-    enable_default_logger(level=args.log_level)
+    enable_default_logger(log_file=args.log_file)
     loop = asyncio.get_event_loop()
     task = loop.create_task(main(subnet_tag=args.subnet_tag))
     try:

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -14,7 +14,9 @@ TEXT_COLOR_DEFAULT = "\033[0m"
 
 def build_parser(description: str):
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("--subnet-tag", default="devnet-alpha.2", help="Subnet name; default: %(default)s")
+    parser.add_argument(
+        "--subnet-tag", default="devnet-alpha.2", help="Subnet name; default: %(default)s"
+    )
     parser.add_argument(
         "--log-file", default=None, help="Log file for YAPAPI; default: %(default)s"
     )

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,12 +1,11 @@
 """Utilities for yapapi example scripts."""
 import argparse
-import logging
 
 
 def build_parser(description: str):
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("--subnet-tag", default="testnet")
+    parser.add_argument("--subnet-tag", default="testnet", help="Subnet name; default: %(default)s")
     parser.add_argument(
-        "--debug", dest="log_level", action="store_const", const=logging.DEBUG, default=logging.INFO
+        "--log-file", default=None, help="Log file for YAPAPI; default: %(default)s"
     )
     return parser

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -10,8 +10,8 @@ These functions should be passed as `event_emitter` arguments to `Engine()`.
 * Functions that perform configuration of the `logging` module itself.
 Since logging configuration is in general a responsibility of the code that
 uses `yapapi` as a library, we only provide the `enable_default_logger`
-function in this category, that enables logging to stderr with given level
-(`logging.DEBUG` by default).
+function in this category, that enables logging to stderr with level `logging.INFO`
+and, optionally, to a given file with level `logging.DEBUG`.
 
 
 Functions for handling events
@@ -55,17 +55,29 @@ logger = logging.getLogger("yapapi.runner")
 
 
 def enable_default_logger(
-    format_: str = "[%(asctime)s %(levelname)s %(name)s] %(message)s", level: int = logging.DEBUG
+    format_: str = "[%(asctime)s %(levelname)s %(name)s] %(message)s",
+    log_file: Optional[str] = None,
 ):
-    """Enable the default logger that logs messages to stderr."""
+    """Enable the default logger that logs messages to stderr with level `INFO`.
 
+    If `log_file` is specified, the logger with output messages with level `DEBUG` to
+    the given file.
+    """
     logger = logging.getLogger("yapapi")
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(format_))
-    handler.setLevel(level)
-    logger.addHandler(handler)
-    logger.setLevel(level)
+    logger.setLevel(logging.DEBUG)
     logger.disabled = False
+    formatter = logging.Formatter(format_)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    console_handler.setLevel(logging.INFO)
+    logger.addHandler(console_handler)
+
+    if log_file:
+        file_handler = logging.FileHandler(filename=log_file, mode="w")
+        file_handler.setFormatter(formatter)
+        file_handler.setLevel(logging.DEBUG)
+        logger.addHandler(file_handler)
 
 
 # Default human-readable representation of event types.


### PR DESCRIPTION
Resolves #67 

Changes:
* `yapapi.log.enable_default_logger()` logs with level `INFO` to stderr (previously: `DEBUG`, but overriden to `INFO` in `blender.py`) and with level `DEBUG` to a file specified as an argument (default: disabled)
* `blender.py` will setup `DEBUG`-level logging to `blender-yapapi.log` file (configurable with `--log-file` cmdline arg) 