### PR TITLE
Log failed execscript commands

### DIFF
--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -314,6 +314,17 @@ class SummaryLogger:
                 self.task_data[event.task_id] if event.task_id else "<initialization>",
             )
 
+        elif isinstance(event, events.CommandExecuted):
+            if event.success:
+                return
+            provider_name = self.agreement_provider_name[event.agr_id]
+            self.logger.warning(
+                "Command failed on provider '%s', command: %s, output: %s",
+                provider_name,
+                event.command,
+                event.message,
+            )
+
         elif isinstance(event, events.ScriptFinished):
             provider_name = self.agreement_provider_name[event.agr_id]
             self.logger.info(

--- a/yapapi/runner/events.py
+++ b/yapapi/runner/events.py
@@ -174,7 +174,9 @@ class ScriptSent(ScriptEvent):
 
 @dataclass
 class CommandExecuted(ScriptEvent):
+    success: bool
     cmd_idx: int
+    command: Any
     message: str
 
 


### PR DESCRIPTION
Resolves #64

Sample output after changes:
```
[2020-10-05 17:42:00,035 WARNING yapapi.summary] Command failed on provider 'tworec@lukaszglen-testnet', command: {'transfer': {'from': 'container:/golem/output/out0020.png', 'to': 'gftp://0xeb692add8545111cc230467f3c465ac4364798a9/9EPo6skOziOC1yCzbk9F4ZLIKjWbzkxfHUkEYw20JREba3bQCr7rC7A9gT0DoH7mL'}}, output: stderr: Local service error: Transfer error: IO error: No such file or directory (os error 2)
```

The logger `yapapi.runner` will also output commands that are executed succesfully:
```
[2020-10-05 17:28:29,614 DEBUG yapapi.runner] CommandExecuted(agr_id='8fb58b96-93e5-4955-8cd5-dfec455ed779', task_id='1', success=True, cmd_idx=2, command={'transfer': {'from': 'gftp://0xeb692add8545111cc230467f3c465ac4364798a9/ee82d5dc7188611da558c76e777a2df7867d9526eac6fa9378728d44ca4a2a10', 'to': 'container:/golem/resource/scene.blend'}}, message=None)
```
```