### PR TITLE
Emit warning if no proposals have been received

### DIFF
--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -43,6 +43,7 @@ as an argument to `log_summary`:
 """
 from collections import defaultdict, Counter
 from dataclasses import asdict
+from datetime import timedelta
 import itertools
 import logging
 import time
@@ -88,6 +89,7 @@ event_type_to_string = {
     events.SubscriptionCreated: "Demand published on the market",
     events.SubscriptionFailed: "Demand publication failed",
     events.CollectFailed: "Failed to collect proposals for demand",
+    events.NoProposalsConfirmed: "No proposals confirmed by providers",
     events.ProposalReceived: "Proposal received from the market",
     events.ProposalRejected: "Proposal rejected",  # by who? alt: Rejected a proposal?
     events.ProposalResponded: "Responded to a proposal",
@@ -224,6 +226,9 @@ class SummaryLogger:
     # Has computation finished?
     finished: bool
 
+    # Total time waiting for the first proposal
+    time_waiting_for_proposals: timedelta
+
     def __init__(self, wrapped_emitter: Optional[Callable[[events.Event], None]] = None):
         """Create a SummaryLogger."""
 
@@ -245,6 +250,7 @@ class SummaryLogger:
         self.provider_failures = Counter()
         self.finished = False
         self.error_occurred = False
+        self.time_waiting_for_proposals = timedelta(0)
 
     def _print_total_cost(self) -> None:
 
@@ -289,6 +295,24 @@ class SummaryLogger:
             self.logger.info(
                 "Received proposals from %s providers so far", len(confirmed_providers)
             )
+
+        elif isinstance(event, events.NoProposalsConfirmed):
+            self.time_waiting_for_proposals += event.timeout
+            if event.num_offers == 0:
+                msg = (
+                    "No offers have been collected from the market for"
+                    f" {self.time_waiting_for_proposals.seconds}s."
+                )
+            else:
+                msg = (
+                    f"{event.num_offers} offers have been collected from the market, but"
+                    f" no provider has responded for {self.time_waiting_for_proposals.seconds}s."
+                )
+            msg += (
+                " Make sure you're using correct versions of yagna and yapapi,"
+                " and the correct subnet."
+            )
+            self.logger.warning(msg)
 
         elif isinstance(event, events.AgreementCreated):
             provider_name = event.provider_id.name
@@ -372,6 +396,9 @@ class SummaryLogger:
                     "Activity failed %s time(s) on provider '%s'", count, provider_name
                 )
             self._print_total_cost()
+
+        elif isinstance(event, events.ComputationFailed):
+            self.logger.error(f"Computation failed, reason: %s", event.reason)
 
 
 def log_summary(wrapped_emitter: Optional[Callable[[events.Event], None]] = None):

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -309,7 +309,7 @@ class SummaryLogger:
                     f" no provider has responded for {self.time_waiting_for_proposals.seconds}s."
                 )
             msg += (
-                " Make sure you're using correct versions of yagna and yapapi,"
+                " Make sure you're using the latest relesed versions of yagna and yapapi,"
                 " and the correct subnet."
             )
             self.logger.warning(msg)

--- a/yapapi/runner/__init__.py
+++ b/yapapi/runner/__init__.py
@@ -63,6 +63,7 @@ CFF_DEFAULT_PRICE_FOR_COUNTER: Final[Mapping[com.Counter, Decimal]] = MappingPro
 class _EngineConf:
     max_workers: int = 5
     timeout: timedelta = timedelta(minutes=5)
+    get_offers_timeout: timedelta = timedelta(seconds=20)
     traceback: bool = bool(os.getenv("YAPAPI_TRACEBACK", 0))
 
 
@@ -266,6 +267,9 @@ class Engine(AsyncContextManager):
         invoices: Dict[str, rest.payment.Invoice] = dict()
         payment_closing: bool = False
 
+        offers_collected = 0
+        proposals_confirmed = 0
+
         async def process_invoices() -> None:
             assert self._budget_allocation
             allocation: rest.payment.Allocation = self._budget_allocation
@@ -304,6 +308,7 @@ class Engine(AsyncContextManager):
             return True
 
         async def find_offers() -> None:
+            nonlocal offers_collected, proposals_confirmed
             try:
                 subscription = await builder.subscribe(market_api)
             except Exception as ex:
@@ -318,6 +323,7 @@ class Engine(AsyncContextManager):
                     raise
                 async for proposal in proposals:
                     emit(events.ProposalReceived(prop_id=proposal.id, provider_id=proposal.issuer))
+                    offers_collected += 1
                     try:
                         score = await strategy.score_offer(proposal)
                     except InvalidPropertiesError as err:
@@ -336,6 +342,7 @@ class Engine(AsyncContextManager):
                     else:
                         emit(events.ProposalConfirmed(prop_id=proposal.id))
                         offer_buffer[proposal.issuer] = _BufferItem(datetime.now(), score, proposal)
+                        proposals_confirmed += 1
 
         # aio_session = await self._stack.enter_async_context(aiohttp.ClientSession())
         # storage_manager = await DavStorageProvider.for_directory(
@@ -468,6 +475,7 @@ class Engine(AsyncContextManager):
         process_invoices_job = loop.create_task(process_invoices())
         wait_until_done = loop.create_task(work_queue.wait_until_done())
         # Py38: find_offers_task.set_name('find_offers_task')
+
         try:
             get_done_task: Optional[asyncio.Task] = None
             services = {
@@ -478,8 +486,17 @@ class Engine(AsyncContextManager):
             }
 
             while wait_until_done in services or not done_queue.empty():
-                if datetime.now(timezone.utc) > self._expires:
+
+                now = datetime.now(timezone.utc)
+                if now > self._expires:
                     raise TimeoutError(f"task timeout exceeded. timeout={self._conf.timeout}")
+                if now > self._get_offers_deadline and proposals_confirmed == 0:
+                    emit(
+                        events.NoProposalsConfirmed(
+                            num_offers=offers_collected, timeout=self._conf.get_offers_timeout
+                        )
+                    )
+                    self._get_offers_deadline += self._conf.get_offers_timeout
 
                 if not get_done_task:
                     get_done_task = loop.create_task(done_queue.get())
@@ -510,13 +527,14 @@ class Engine(AsyncContextManager):
                     get_done_task = None
 
             emit(events.ComputationFinished())
+
         except Exception as e:
             if (
                 not isinstance(e, (KeyboardInterrupt, asyncio.CancelledError))
                 and self._conf.traceback
             ):
                 traceback.print_exc()
-            emit(events.ComputationFailed(reason=str(e)))
+            emit(events.ComputationFailed(reason=e.__repr__()))
 
         finally:
             payment_closing = True
@@ -548,6 +566,7 @@ class Engine(AsyncContextManager):
 
         # TODO: Cleanup on exception here.
         self._expires = datetime.now(timezone.utc) + self._conf.timeout
+        self._get_offers_deadline = datetime.now(timezone.utc) + self._conf.get_offers_timeout
         market_client = await stack.enter_async_context(self._api_config.market())
         self._market_api = rest.Market(market_client)
 

--- a/yapapi/runner/events.py
+++ b/yapapi/runner/events.py
@@ -1,5 +1,6 @@
 """Representing events in Golem computation."""
 import dataclasses
+from datetime import timedelta
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Any, Optional, Type, Tuple
@@ -79,6 +80,12 @@ class ProposalConfirmed(ProposalEvent):
 @dataclass
 class ProposalFailed(ProposalEvent):
     reason: str
+
+
+@dataclass
+class NoProposalsConfirmed(Event):
+    num_offers: int
+    timeout: timedelta
 
 
 @dataclass(init=False)


### PR DESCRIPTION
Resolves #63

Example output when no offers have been collected:
```
[2020-10-06 15:14:02,778 WARNING yapapi.summary] No offers have been collected from the market for 20s. Make sure you're using correct versions of yagna and yapapi, and the correct subnet.
[2020-10-06 15:14:22,783 WARNING yapapi.summary] No offers have been collected from the market for 40s. Make sure you're using correct versions of yagna and yapapi, and the correct subnet.
```
When some offers have been collected but no provider responded
to counter-proposals:
```
[2020-10-06 15:11:23,795 WARNING yapapi.summary] 18 offers have been collected from the market, but no provider responded for 20s. Make sure you're using correct versions of yagna and yapapi, and the correct subnet.
```

Also: 
resolves #72 

Example output:
```
[2020-10-06 16:17:26,907 ERROR yapapi.summary] Computation failed, reason: TimeoutError('task timeout exceeded. timeout=0:00:05')
```
