### PR TITLE
Add exception information to `ComputationFinished` event.

### DIFF
--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -359,7 +359,7 @@ class Executor(AsyncContextManager):
                                 assert exc_typ is not None and exc_val is not None
                                 emit(
                                     events.WorkerFinished(
-                                        agr_id=agreement.id, exception=(exc_typ, exc_val, exc_tb)
+                                        agr_id=agreement.id, exc_info=(exc_typ, exc_val, exc_tb)
                                     )
                                 )
                                 return
@@ -456,7 +456,9 @@ class Executor(AsyncContextManager):
                 and self._conf.traceback
             ):
                 traceback.print_exc()
-            emit(events.ComputationFailed(reason=e.__repr__()))
+            (exc_typ, exc_val, exc_tb) = sys.exc_info()
+            assert exc_typ is not None and exc_val is not None
+            emit(events.ComputationFinished(exc_info=(exc_typ, exc_val, exc_tb)))
 
         finally:
             payment_closing = True

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -260,17 +260,17 @@ class SummaryLogger:
             self.agreement_provider_name[agr_id] for agr_id in self.confirmed_agreements
         }
         self.logger.info(
-            "Negotiated %s agreements with %s providers",
+            "Negotiated %d agreements with %d providers",
             len(self.confirmed_agreements),
             len(agreement_providers),
         )
         for provider_name, tasks in self.provider_tasks.items():
-            self.logger.info("Provider '%s' computed %s tasks", provider_name, len(tasks))
+            self.logger.info("Provider '%s' computed %d tasks", provider_name, len(tasks))
         for provider_name in set(self.agreement_provider_name.values()):
             if provider_name not in self.provider_tasks:
                 self.logger.info("Provider '%s' did not compute any tasks", provider_name)
         for provider_name, count in self.provider_failures.items():
-            self.logger.info("Activity failed %s time(s) on provider '%s'", count, provider_name)
+            self.logger.info("Activity failed %d time(s) on provider '%s'", count, provider_name)
         self._print_total_cost()
 
     def _print_total_cost(self) -> None:

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -85,7 +85,6 @@ def enable_default_logger(
 event_type_to_string = {
     events.ComputationStarted: "Computation started",
     events.ComputationFinished: "Computation finished",
-    events.ComputationFailed: "Computation failed",
     events.SubscriptionCreated: "Demand published on the market",
     events.SubscriptionFailed: "Demand publication failed",
     events.CollectFailed: "Failed to collect proposals for demand",
@@ -252,6 +251,28 @@ class SummaryLogger:
         self.error_occurred = False
         self.time_waiting_for_proposals = timedelta(0)
 
+    def _print_summary(self) -> None:
+        """Print a summary at the end of computation."""
+
+        total_time = time.time() - self.start_time
+        self.logger.info(f"Computation finished in {total_time:.1f}s")
+        agreement_providers = {
+            self.agreement_provider_name[agr_id] for agr_id in self.confirmed_agreements
+        }
+        self.logger.info(
+            "Negotiated %s agreements with %s providers",
+            len(self.confirmed_agreements),
+            len(agreement_providers),
+        )
+        for provider_name, tasks in self.provider_tasks.items():
+            self.logger.info("Provider '%s' computed %s tasks", provider_name, len(tasks))
+        for provider_name in set(self.agreement_provider_name.values()):
+            if provider_name not in self.provider_tasks:
+                self.logger.info("Provider '%s' did not compute any tasks", provider_name)
+        for provider_name, count in self.provider_failures.items():
+            self.logger.info("Activity failed %s time(s) on provider '%s'", count, provider_name)
+        self._print_total_cost()
+
     def _print_total_cost(self) -> None:
 
         if not self.finished:
@@ -367,38 +388,24 @@ class SummaryLogger:
             self._print_total_cost()
 
         elif isinstance(event, events.WorkerFinished):
-            if event.exception is None:
+            if event.exc_info is None:
                 return
-            exc_type, exc, tb = event.exception
+            _exc_type, exc, _tb = event.exc_info
             provider_name = self.agreement_provider_name[event.agr_id]
             self.provider_failures[provider_name] += 1
-            self.logger.warning("Activity failed on provider '%s', reason: %r", provider_name, exc)
+            reason = str(exc) or repr(exc) or "unexpected error"
+            self.logger.warning(
+                "Activity failed on provider '%s', reason: %s", provider_name, reason
+            )
 
         elif isinstance(event, events.ComputationFinished):
-            self.finished = True
-            total_time = time.time() - self.start_time
-            self.logger.info(f"Computation finished in {total_time:.1f}s")
-            agreement_providers = {
-                self.agreement_provider_name[agr_id] for agr_id in self.confirmed_agreements
-            }
-            self.logger.info(
-                "Negotiated %s agreements with %s providers",
-                len(self.confirmed_agreements),
-                len(agreement_providers),
-            )
-            for provider_name, tasks in self.provider_tasks.items():
-                self.logger.info("Provider '%s' computed %s tasks", provider_name, len(tasks))
-            for provider_name in set(self.agreement_provider_name.values()):
-                if provider_name not in self.provider_tasks:
-                    self.logger.info("Provider '%s' did not compute any tasks", provider_name)
-            for provider_name, count in self.provider_failures.items():
-                self.logger.info(
-                    "Activity failed %s time(s) on provider '%s'", count, provider_name
-                )
-            self._print_total_cost()
-
-        elif isinstance(event, events.ComputationFailed):
-            self.logger.error(f"Computation failed, reason: %s", event.reason)
+            if not event.exc_info:
+                self.finished = True
+                self._print_summary()
+            else:
+                _exc_type, exc, _tb = event.exc_info
+                reason = str(exc) or repr(exc) or "unexpected error"
+                self.logger.error(f"Computation failed, reason: %s", reason)
 
 
 def log_summary(wrapped_emitter: Optional[Callable[[events.Event], None]] = None):


### PR DESCRIPTION
Resolves #101 

See #101 for details. May help in diagnosing #76.

Changes:

* Summary logger uses `str(e) or repr(e) or "Unknown error"` instead of `repr(e)` to print the reason of failure (`repr(e)` gives insufficient info for `ApiError()`, `str(e)` is empty for some other error types). For example:
  ```
  [2020-10-21 15:49:12,086 ERROR yapapi.summary] Computation failed, reason: task timeout exceeded. timeout=0:27:00
  ```
 
* Exception info is included in the event emitted when computation fails, and is used to print traceback to DEBUG log:
  ```
  [2020-10-21 15:49:12,085 DEBUG yapapi.executor] ComputationFinished(exc_info=(<class 'TimeoutError'>, TimeoutError('task timeout exceeded. timeout=0:27:00'), <traceback object at 0x7f99e9dffc80>))
  Traceback (most recent call last):
  File "/home/azawlocki/golem/yagna-integration/yapapi/yapapi/executor/__init__.py", line 414, in submit
    raise TimeoutError(f"task timeout exceeded. timeout={self._conf.timeout}")
  ```

* The `ComputationFailed` event is removed. Both success and failure are represented by `ComputationFinished`. Failure is indicated by setting its `exc_info` field. This is similar to how worker failures are represented.