### PR TITLE
add a work-around to make the examples work on win+py3.6/3.7

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -86,7 +86,8 @@ if __name__ == "__main__":
     parser.set_defaults(log_file="blender-yapapi.log")
     args = parser.parse_args()
 
-    utils.asyncio_fix()
+    # This is only required when running on Windows with Python prior to 3.8:
+    utils.windows_event_loop_fix()
 
     enable_default_logger(log_file=args.log_file)
     loop = asyncio.get_event_loop()

--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -86,6 +86,8 @@ if __name__ == "__main__":
     parser.set_defaults(log_file="blender-yapapi.log")
     args = parser.parse_args()
 
+    utils.asyncio_fix()
+
     enable_default_logger(log_file=args.log_file)
     loop = asyncio.get_event_loop()
     subnet = args.subnet_tag

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,5 +1,7 @@
 """Utilities for yapapi example scripts."""
 import argparse
+import asyncio
+import sys
 
 TEXT_COLOR_RED = "\033[31;1m"
 TEXT_COLOR_GREEN = "\033[32;1m"
@@ -21,3 +23,11 @@ def build_parser(description: str):
         "--log-file", default=None, help="Log file for YAPAPI; default: %(default)s"
     )
     return parser
+
+def asyncio_fix():
+
+    class _WindowsEventPolicy(asyncio.events.BaseDefaultEventLoopPolicy):
+        _loop_factory = asyncio.windows_events.ProactorEventLoop
+
+    if sys.platform == 'win32':
+        asyncio.set_event_loop_policy(_WindowsEventPolicy())

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -25,9 +25,8 @@ def build_parser(description: str):
     return parser
 
 def asyncio_fix():
-
-    class _WindowsEventPolicy(asyncio.events.BaseDefaultEventLoopPolicy):
-        _loop_factory = asyncio.windows_events.ProactorEventLoop
-
     if sys.platform == 'win32':
+        class _WindowsEventPolicy(asyncio.events.BaseDefaultEventLoopPolicy):
+            _loop_factory = asyncio.windows_events.ProactorEventLoop
+
         asyncio.set_event_loop_policy(_WindowsEventPolicy())

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -26,7 +26,7 @@ def build_parser(description: str):
 
 
 def asyncio_fix():
-    if sys.platform == "win32":
+    if sys.platform == "win32" and sys.version_info[0] == 3 and sys.version_info[1] <= 7:
 
         class _WindowsEventPolicy(asyncio.events.BaseDefaultEventLoopPolicy):
             _loop_factory = asyncio.windows_events.ProactorEventLoop

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -25,8 +25,11 @@ def build_parser(description: str):
     return parser
 
 
-def asyncio_fix():
-    if sys.platform == "win32" and sys.version_info[0] == 3 and sys.version_info[1] <= 7:
+def windows_event_loop_fix():
+    """Set up asyncio to use ProactorEventLoop implementation for new event loops on Windows."""
+
+    # For Python 3.8 ProactorEventLoop is already the default on Windows
+    if sys.platform == "win32" and sys.version_info < (3, 8):
 
         class _WindowsEventPolicy(asyncio.events.BaseDefaultEventLoopPolicy):
             _loop_factory = asyncio.windows_events.ProactorEventLoop

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -24,8 +24,10 @@ def build_parser(description: str):
     )
     return parser
 
+
 def asyncio_fix():
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
+
         class _WindowsEventPolicy(asyncio.events.BaseDefaultEventLoopPolicy):
             _loop_factory = asyncio.windows_events.ProactorEventLoop
 

--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -140,6 +140,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    utils.asyncio_fix()
+
     enable_default_logger(log_file=args.log_file)
 
     sys.stderr.write(

--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -140,7 +140,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    utils.asyncio_fix()
+    # This is only required when running on Windows with Python prior to 3.8:
+    utils.windows_event_loop_fix()
 
     enable_default_logger(log_file=args.log_file)
 


### PR DESCRIPTION
backwards-compatible port of https://github.com/golemfactory/yapapi/pull/105 which only fixes the examples but doesn't make the work-around part of the library