### PR TITLE
Timeouts for batches of commads

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -55,10 +55,10 @@ async def main(subnet_tag: str):
             output_file = f"output_{frame}.png"
             ctx.download_file(f"/golem/output/out{frame:04d}.png", output_file)
             try:
-                # Set timeout for executing the script on the provider.
-                # If the timeout is exceeded, this worker instance will be
-                # shut down and all remaining tasks, including the current one,
-                # will be computed by other providers (hopefully).
+                # Set timeout for executing the script on the provider. Two minutes is plenty
+                # of time for computing a single frame, for other tasks it may be not enough.
+                # If the timeout is exceeded, this worker instance will be shut down and all
+                # remaining tasks, including the current one, will be computed by other providers.
                 yield ctx.commit(timeout=timedelta(seconds=120))
                 # TODO: Check if job results are valid
                 # and reject by: task.reject_task(reason = 'invalid file')

--- a/tests/rest/test_allocation.py
+++ b/tests/rest/test_allocation.py
@@ -17,7 +17,7 @@ async def test_allocation(yapapi_payment: Payment):
     async for a in yapapi_payment.allocations():
         print("a=", a)
 
-    async with yapapi_payment.new_allocation(amount=Decimal(40)) as allocation:
+    async with yapapi_payment.new_allocation(Decimal(40), "NGNT", "mockaddress") as allocation:
         found = False
         async for a in yapapi_payment.allocations():
             if a.id == allocation.id:

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -298,13 +298,14 @@ class Executor(AsyncContextManager):
             try:
                 act = await activity_api.new_activity(agreement.id)
             except Exception:
-                emit(events.ActivityCreateFailed(agr_id=agreement.id))
+                emit(events.ActivityCreateFailed(agr_id=agreement.id, exc_info=sys.exc_info()))
                 raise
             async with act:
                 emit(events.ActivityCreated(act_id=act.id, agr_id=agreement.id))
 
                 work_context = WorkContext(f"worker-{wid}", storage_manager, emitter=emit)
                 with work_queue.new_consumer() as consumer:
+
                     command_generator = worker(
                         work_context,
                         (Task.for_handle(handle, work_queue, emit) async for handle in consumer),

--- a/yapapi/executor/events.py
+++ b/yapapi/executor/events.py
@@ -155,7 +155,7 @@ class ActivityCreated(AgreementEvent):
 
 
 @dataclass
-class ActivityCreateFailed(AgreementEvent):
+class ActivityCreateFailed(HasExcInfo, AgreementEvent):
     pass
 
 

--- a/yapapi/executor/task.py
+++ b/yapapi/executor/task.py
@@ -26,6 +26,7 @@ class Task(Generic[TaskData, TaskResult]):
     Represents one computation unit that will be run on the provider
     (e.g. rendering of one frame of an animation).
     """
+
     ids: ClassVar[Iterator[int]] = itertools.count(1)
 
     def __init__(

--- a/yapapi/executor/task.py
+++ b/yapapi/executor/task.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum, auto
 import itertools
 from typing import Callable, ClassVar, Iterator, Generic, Optional, Set, Tuple, TypeVar, Union
@@ -26,34 +26,23 @@ class Task(Generic[TaskData, TaskResult]):
     Represents one computation unit that will be run on the provider
     (e.g. rendering of one frame of an animation).
     """
-
     ids: ClassVar[Iterator[int]] = itertools.count(1)
 
     def __init__(
-        self,
-        data: TaskData,
-        *,
-        expires: Optional[datetime] = None,
-        timeout: Optional[timedelta] = None,
+        self, data: TaskData,
     ):
         """Create a new Task object.
 
         :param data: contains information needed to prepare command list for the provider
-        :param expires: expiration datetime
-        :param timeout: timeout from now; overrides expires parameter if provided
         """
         self.id: str = str(next(Task.ids))
-        self._started = datetime.now()
-        self._expires: Optional[datetime]
+        self._started: Optional[datetime] = None
+        self._finished: Optional[datetime] = None
         self._emit: Optional[Callable[[TaskEvents], None]] = None
         self._callbacks: Set[Callable[["Task[TaskData, TaskResult]", TaskStatus], None]] = set()
         self._handle: Optional[
             Tuple[Handle["Task[TaskData, TaskResult]"], SmartQueue["Task[TaskData, TaskResult]"]]
         ] = None
-        if timeout:
-            self._expires = self._started + timeout
-        else:
-            self._expires = expires
 
         self._result: Optional[TaskResult] = None
         self._data = data
@@ -70,8 +59,11 @@ class Task(Generic[TaskData, TaskResult]):
     def _start(self, emitter: Callable[[TaskEvents], None]) -> None:
         self._status = TaskStatus.RUNNING
         self._emit = emitter
+        self._started = datetime.now(timezone.utc)
+        self._finished = None
 
     def _stop(self, retry: bool = False):
+        self._finished = datetime.now(timezone.utc)
         if self._handle:
             (handle, queue) = self._handle
             loop = asyncio.get_event_loop()
@@ -100,8 +92,14 @@ class Task(Generic[TaskData, TaskResult]):
         return self._result
 
     @property
-    def expires(self) -> Optional[datetime]:
-        return self._expires
+    def running_time(self) -> Optional[timedelta]:
+        """Return the running time of the task (if in progress) or time it took to complete it."""
+        if self._finished:
+            assert self._started
+            return self._finished - self._started
+        if self._started:
+            return datetime.now(timezone.utc) - self._started
+        return None
 
     def accept_result(self, result: Optional[TaskResult] = None) -> None:
         """Accept the result of this task.

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -58,6 +58,9 @@ logger = logging.getLogger("yapapi.executor")
 def enable_default_logger(
     format_: str = "[%(asctime)s %(levelname)s %(name)s] %(message)s",
     log_file: Optional[str] = None,
+    debug_activity_api: bool = False,
+    debug_market_api: bool = False,
+    debug_payment_api: bool = False,
 ):
     """Enable the default logger that logs messages to stderr with level `INFO`.
 
@@ -79,6 +82,16 @@ def enable_default_logger(
         file_handler.setFormatter(formatter)
         file_handler.setLevel(logging.DEBUG)
         logger.addHandler(file_handler)
+
+        for flag, logger_name in (
+            (debug_activity_api, "ya_activity"),
+            (debug_market_api, "ya_market"),
+            (debug_payment_api, "ya_payment"),
+        ):
+            if flag:
+                api_logger = logging.getLogger(logger_name)
+                api_logger.setLevel(logging.DEBUG)
+                api_logger.addHandler(file_handler)
 
 
 # Default human-readable representation of event types.

--- a/yapapi/rest/activity.py
+++ b/yapapi/rest/activity.py
@@ -99,8 +99,14 @@ class Activity(AsyncContextManager["Activity"]):
                 await self._api.get_exec_batch_results(self._id, batch_id, timeout=1.0)
         except yexc.ApiException as err:
             # Suppress errors that say that this activity does not exist (we're closing it anyway).
-            msg = f"No service registered under given address '/public/exeunit/{self._id}/Exec'"
-            level = logging.ERROR if err.status != 500 or msg not in err.body else logging.DEBUG
+            msg_to_suppress = (
+                f"No service registered under given address '/public/exeunit/{self._id}/Exec'"
+            )
+            level = (
+                logging.ERROR
+                if err.status != 500 or msg_to_suppress not in err.body
+                else logging.DEBUG
+            )
             _log.log(level, "failed to destroy activity: %s", self._id, exc_info=True)
         finally:
             with contextlib.suppress(yexc.ApiException):


### PR DESCRIPTION
Resolves #112 
Resolves #113 
Resolves #117 

* Attributes `timeout` and `expires` are removed from the `Task` class (they were not used so no functionality is lost).
* Parameter `timeout` is added to `WorkContext.commit()`. It's the timeout for the whole script created by `WorkContext.commit()`. This timeout is enforced using the `timeout` request parameter of the Activity API entrypoint for querying batch results.
* Exceeding this timeout causes `BatchTimeoutError()` to be raised.