### PR TITLE
Support for command output streaming

### DIFF
--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -299,10 +299,11 @@ class Executor(AsyncContextManager):
             try:
                 act = await activity_api.new_activity(agreement.id)
             except Exception:
-                exc_info = sys.exc_info()
-                assert exc_info[0] is not None and exc_info[1] is not None  # for mypy
-                emit(events.ActivityCreateFailed(agr_id=agreement.id, exc_info=exc_info))
-
+                emit(
+                    events.ActivityCreateFailed(
+                        agr_id=agreement.id, exc_info=sys.exc_info()  # type: ignore
+                    )
+                )
                 raise
             async with act:
                 emit(events.ActivityCreated(act_id=act.id, agr_id=agreement.id))
@@ -356,11 +357,9 @@ class Executor(AsyncContextManager):
                             except Exception:
                                 if self._conf.traceback:
                                     traceback.print_exc()
-                                (exc_typ, exc_val, exc_tb) = sys.exc_info()
-                                assert exc_typ is not None and exc_val is not None
                                 emit(
                                     events.WorkerFinished(
-                                        agr_id=agreement.id, exc_info=(exc_typ, exc_val, exc_tb)
+                                        agr_id=agreement.id, exc_info=sys.exc_info()  # type: ignore
                                     )
                                 )
                                 return
@@ -458,9 +457,7 @@ class Executor(AsyncContextManager):
                 and self._conf.traceback
             ):
                 traceback.print_exc()
-            (exc_typ, exc_val, exc_tb) = sys.exc_info()
-            assert exc_typ is not None and exc_val is not None
-            emit(events.ComputationFinished(exc_info=(exc_typ, exc_val, exc_tb)))
+            emit(events.ComputationFinished(exc_info=sys.exc_info()))  # type: ignore
 
         finally:
             payment_closing = True

--- a/yapapi/executor/ctx.py
+++ b/yapapi/executor/ctx.py
@@ -239,8 +239,8 @@ class WorkContext:
         :param env: optional dictionary with environmental variables
         :return: None
         """
-        stdout = CaptureContext.build()
-        stderr = CaptureContext.build()
+        stdout = CaptureContext.build(mode="stream")
+        stderr = CaptureContext.build(mode="stream")
 
         self.__prepare()
         self._pending_steps.append(_Run(cmd, *args, env=env, stdout=stdout, stderr=stderr))

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -412,38 +412,6 @@ class SummaryLogger:
                 reason = str(exc) or repr(exc) or "unexpected error"
                 self.logger.error(f"Computation failed, reason: %s", reason)
 
-        elif isinstance(event, events.CommandStarted):
-            self.logger.info(
-                f"Command started (task {event.task_id}, idx {event.cmd_idx}): {event.command}"
-            )
-
-        elif isinstance(event, events.CommandExecuted):
-            if event.success:
-                # display the output with:
-                # self.logger.info(
-                #     f"Command finished (task {event.task_id}, idx {event.cmd_idx}): {event.message}"
-                # )
-                # event.message is set in activity.py:145
-                return
-
-            provider_name = self.agreement_provider_name[event.agr_id]
-            self.logger.warning(
-                "Command failed on provider '%s', command: %s, output: %s",
-                provider_name,
-                event.command,
-                event.message,
-            )
-
-        elif isinstance(event, events.CommandStdOut):
-            self.logger.info(
-                f"Command stdout (task {event.task_id}, idx {event.cmd_idx}): {event.output.rstrip()}"
-            )
-
-        elif isinstance(event, events.CommandStdErr):
-            self.logger.warning(
-                f"Command stderr (task {event.task_id}, idx {event.cmd_idx}): {event.output.rstrip()}"
-            )
-
 
 def log_summary(wrapped_emitter: Optional[Callable[[events.Event], None]] = None):
     """Output a summary of computation.


### PR DESCRIPTION
* The `Executor` now uses `EventSource` interface from [aiohttp-sse](https://github.com/aio-libs/aiohttp-sse) for getting updates on commands running on the provider.
* Standard output/error of the remote command is received in chunks, not as a single block. That's how it looks in the log file for the `blender` example:
   ```
  [2020-11-16 16:35:47,673 DEBUG yapapi.executor] CommandStdOut(agr_id='f92d55a950bff38377944979c7272657f8f219c69b320aad791d39d1381a9a70', task_id='1', cmd_idx=4, output='Blender 2.80 (sub 75) (hash f6cb5f54494e built 2019-07-29 17:17:04)\n')
  [2020-11-16 16:35:47,733 DEBUG yapapi.executor] CommandStdOut(agr_id='f92d55a950bff38377944979c7272657f8f219c69b320aad791d39d1381a9a70', task_id='1', cmd_idx=4, output='found bundled python: /blender/2.80/python\n') 
  ```
* Errors from the `run` command are correctly reported (instead of allowing `run` to fail silently and then report `TransferError` for the next command):
   ```
   [2020-11-16 16:37:48,186 WARNING yapapi.summary] Activity failed on provider 'tworec@mf-devnet-alpha.3', reason: Command '{'run': {'entry_point': '/golem/entrypoints/dont-run-blender.sh', 'args': (), 'capture': {'stdout': {'stream': {}}, 'stderr': {'stream': {}}}}}' failed on provider with message 'Runtime error: Error { code: Internal, message: "Running process failed, exit code: 2", context: {} }'
   ```