### PR TITLE
Make yacat work again 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.4.0-alpha.0"
+version = "0.4.0-alpha.1"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>", "GolemFactory <contact@golem.network>"]
 license = "LGPL-3.0-or-later"

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -485,7 +485,6 @@ class Executor(AsyncContextManager):
             )
 
     async def _create_allocations(self) -> rest.payment.MarketDecoration:
-        ids_to_decorate = []
         if not self._budget_allocations:
             async for account in self._payment_api.accounts():
                 allocation = cast(
@@ -500,11 +499,11 @@ class Executor(AsyncContextManager):
                     ),
                 )
                 self._budget_allocations.append(allocation)
-                ids_to_decorate.append(allocation.id)
         assert (
             self._budget_allocations
         ), "No payment accounts. Did you forget to run 'yagna payment init -r'?"
-        return await self._payment_api.decorate_demand(ids_to_decorate)
+        allocation_ids = [allocation.id for allocation in self._budget_allocations]
+        return await self._payment_api.decorate_demand(allocation_ids)
 
     def _get_common_payment_platforms(self, proposal: rest.market.OfferProposal) -> Set[str]:
         prov_platforms = {

--- a/yapapi/rest/activity.py
+++ b/yapapi/rest/activity.py
@@ -167,7 +167,7 @@ class Batch(abc.ABC, AsyncIterable[events.CommandEventContext]):
         self._batch_id = batch_id
         self._size = batch_size
         self._deadline = (
-            deadline if deadline else datetime.now(timezone.utc) + timedelta(days=365000000)
+            deadline if deadline else datetime.now(timezone.utc) + timedelta(days=365000)
         )
 
     def seconds_left(self) -> float:


### PR DESCRIPTION
Resolves #129 

This PR fixes two distinct bugs in `yapapi` that prevented `yacat` from working:

1. `timedelta` value with too large `days` property was used as default timeout for `Batch` object, causing overflow errors.
2. A bug in the coroutine that creates budget allocations caused it to fail with ApiException if the allocations were already created for an `Executor()` instance.