### PR TITLE
Graceful shutdown on Ctrl+C in blender/yacat

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -119,7 +119,20 @@ if __name__ == "__main__":
     task = loop.create_task(main(subnet_tag=args.subnet_tag))
     try:
         loop.run_until_complete(task)
-    except (Exception, KeyboardInterrupt) as e:
-        print(e)
+    except KeyboardInterrupt:
+        print(
+            f"{utils.TEXT_COLOR_YELLOW}"
+            "Shutting down gracefully, please wait a few seconds "
+            "or press Ctrl+C to exit immediately..."
+            f"{utils.TEXT_COLOR_DEFAULT}"
+        )
         task.cancel()
-        loop.run_until_complete(task)
+        try:
+            loop.run_until_complete(task)
+            print(
+                f"{utils.TEXT_COLOR_YELLOW}"
+                "Shutdown completed, thank you for waiting!"
+                f"{utils.TEXT_COLOR_DEFAULT}"
+            )
+        except KeyboardInterrupt:
+            pass

--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -155,7 +155,20 @@ if __name__ == "__main__":
 
     try:
         loop.run_until_complete(task)
-    except (Exception, KeyboardInterrupt) as e:
-        print(e)
+    except KeyboardInterrupt:
+        print(
+            f"{utils.TEXT_COLOR_YELLOW}"
+            "Shutting down gracefully, please wait a few seconds "
+            "or press Ctrl+C to exit immediately..."
+            f"{utils.TEXT_COLOR_DEFAULT}"
+        )
         task.cancel()
-        loop.run_until_complete(task)
+        try:
+            loop.run_until_complete(task)
+            print(
+                f"{utils.TEXT_COLOR_YELLOW}"
+                "Shutdown completed, thank you for waiting!"
+                f"{utils.TEXT_COLOR_DEFAULT}"
+            )
+        except KeyboardInterrupt:
+            pass


### PR DESCRIPTION
Resolves #118 
Improves #132 

Also resolves some issues reported after the last testing session

* All asyncio task are `cancel`led and `gather`ed at the end of `Executor.submit()` to ensure that no "Exception was never retrieved" errors occur at shutdown

* `KeyboardInterrupt` is caught at the end of `blender.py/yacat.py` to ensure that pressing Ctrl+C for the second time does not print traceback