### PR TITLE
Stop script if there was an error when computing the key space

### DIFF
--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -95,9 +95,14 @@ async def main(args):
         event_consumer=log_summary(log_event_repr),
     ) as executor:
 
+        keyspace_computed = False
         # This is not a typical use of executor.submit as there is only one task, with no data:
-        async for task in executor.submit(worker_check_keyspace, [Task(data=None)]):
-            pass
+        async for _task in executor.submit(worker_check_keyspace, [Task(data=None)]):
+            keyspace_computed = True
+
+        if not keyspace_computed:
+            # Assume the errors have been already reported and we may return quietly.
+            return
 
         keyspace = read_keyspace()
 


### PR DESCRIPTION
Resolves #133

We check if the key space size was successfully computed by the first `Executor.submit()` call and exit early if it was not.