### PR TITLE
Catch exceptions in `Executor.__aexit__()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>", "GolemFactory <contact@golem.network>"]
 license = "LGPL-3.0-or-later"

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -225,8 +225,7 @@ class Executor(AsyncContextManager):
                     except Exception:
                         emit(
                             events.PaymentFailed(
-                                agr_id=invoice.agreement_id,
-                                exc_info=sys.exc_info()  # type: ignore
+                                agr_id=invoice.agreement_id, exc_info=sys.exc_info()  # type: ignore
                             )
                         )
                     else:
@@ -506,7 +505,6 @@ class Executor(AsyncContextManager):
                 return_when=asyncio.ALL_COMPLETED,
             )
             if agreements_to_pay:
-                # TODO: remove
                 await asyncio.wait(
                     {process_invoices_job}, timeout=15, return_when=asyncio.ALL_COMPLETED
                 )

--- a/yapapi/executor/events.py
+++ b/yapapi/executor/events.py
@@ -256,3 +256,8 @@ class DownloadStarted(Event):
 @dataclass
 class DownloadFinished(Event):
     path: str
+
+
+@dataclass
+class ShutdownFinished(HasExcInfo):
+    """Indicates the completion of Executor shutdown sequence"""

--- a/yapapi/executor/events.py
+++ b/yapapi/executor/events.py
@@ -139,6 +139,11 @@ class PaymentQueued(AgreementEvent):
 
 
 @dataclass
+class PaymentFailed(HasExcInfo, AgreementEvent):
+    pass
+
+
+@dataclass
 class InvoiceReceived(AgreementEvent):
     inv_id: str
     amount: str

--- a/yapapi/executor/utils.py
+++ b/yapapi/executor/utils.py
@@ -1,9 +1,9 @@
 """Utility functions and classes used within the `yapapi.executor` package."""
 import asyncio
-from typing import AsyncContextManager, Callable, Optional
+from typing import Callable, Optional
 
 
-class AsyncWrapper(AsyncContextManager):
+class AsyncWrapper:
     """Wraps a given callable to provide asynchronous calls.
 
     Example usage:
@@ -27,6 +27,7 @@ class AsyncWrapper(AsyncContextManager):
         self._args_buffer = asyncio.Queue()
         self._task = None
         self._loop = event_loop or asyncio.get_event_loop()
+        self._task = self._loop.create_task(self._worker())
 
     async def _worker(self) -> None:
         while True:
@@ -34,14 +35,15 @@ class AsyncWrapper(AsyncContextManager):
             self._wrapped(*args, **kwargs)
             self._args_buffer.task_done()
 
-    async def __aenter__(self):
-        self._task = self._loop.create_task(self._worker())
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def _delete(self) -> None:
         await self._args_buffer.join()
         if self._task:
             self._task.cancel()
-        self._task = None
+            await asyncio.gather(self._task, return_exceptions=True)
+            self._task = None
+
+    def __del__(self):
+        self._loop.run_until_complete(self._delete())
 
     def async_call(self, *args, **kwargs) -> None:
         """Schedule an asynchronous call to the wrapped callable."""

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -111,6 +111,7 @@ event_type_to_string = {
     events.AgreementConfirmed: "Agreement approved by provider",
     events.AgreementRejected: "Agreement rejected by provider",
     events.PaymentAccepted: "Payment accepted",  # by who?
+    events.PaymentFailed: "Payment failed",
     events.PaymentPrepared: "Payment prepared",
     events.PaymentQueued: "Payment queued",
     events.InvoiceReceived: "Invoice received",  # by who?
@@ -392,6 +393,13 @@ class SummaryLogger:
             cost += float(event.amount)
             self.provider_cost[provider_name] = cost
             self._print_total_cost()
+
+        elif isinstance(event, events.PaymentFailed):
+            assert event.exc_info
+            _exc_type, exc, _tb = event.exc_info
+            provider_name = self.agreement_provider_name[event.agr_id]
+            reason = str(exc) or repr(exc) or "unexpected error"
+            self.logger.error("Payment for provider '%s' failed, reason: %s", provider_name, reason)
 
         elif isinstance(event, events.WorkerFinished):
             if event.exc_info is None:

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -130,6 +130,7 @@ event_type_to_string = {
     events.WorkerFinished: "Worker finished",
     events.DownloadStarted: "Download started",
     events.DownloadFinished: "Download finished",
+    events.ShutdownFinished: "Shutdown finished",
 }
 
 
@@ -411,6 +412,14 @@ class SummaryLogger:
                 _exc_type, exc, _tb = event.exc_info
                 reason = str(exc) or repr(exc) or "unexpected error"
                 self.logger.error(f"Computation failed, reason: %s", reason)
+
+        elif isinstance(event, events.ShutdownFinished):
+            if not event.exc_info:
+                self.logger.info("Executor shut down")
+            else:
+                _exc_type, exc, _tb = event.exc_info
+                reason = str(exc) or repr(exc) or "unexpected error"
+                self.logger.error("Error when shutting down Executor: %s", reason)
 
 
 def log_summary(wrapped_emitter: Optional[Callable[[events.Event], None]] = None):

--- a/yapapi/rest/activity.py
+++ b/yapapi/rest/activity.py
@@ -94,7 +94,7 @@ class Activity(AsyncContextManager["Activity"]):
             batch_id = await self._api.call_exec(
                 self._id, yaa.ExeScriptRequest(text='[{"terminate":{}}]')
             )
-            with contextlib.suppress(yexc.ApiException):
+            with contextlib.suppress(yexc.ApiException, asyncio.TimeoutError):
                 # wait 1sec before kill
                 await self._api.get_exec_batch_results(self._id, batch_id, timeout=1.0)
         except yexc.ApiException as err:


### PR DESCRIPTION
Resolves #138 
Resolves #139 

This PR addresses issues with reporting errors that arise after the computation finishes:
* Errors raised in `Executor.__aexit__()` should not print traceback to the console; a short summary message should be printed to the console and a traceback -- to the log file (#138)
* Errors raised in `process_invoices()` after the computation finishes should not be ignored; a short summary message should be printed to the console and a traceback -- to the log file (#139)