### PR TITLE
Quick shutdown on Ctrl+C

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -71,8 +71,6 @@ async def main(subnet_tag: str):
                 )
                 raise
 
-        ctx.log("no more frames to render")
-
     # iterator over the frame indices that we want to render
     frames: range = range(0, 60, 10)
     # TODO make this dynamic, e.g. depending on the size of files to transfer
@@ -134,5 +132,5 @@ if __name__ == "__main__":
                 "Shutdown completed, thank you for waiting!"
                 f"{utils.TEXT_COLOR_DEFAULT}"
             )
-        except KeyboardInterrupt:
+        except (asyncio.CancelledError, KeyboardInterrupt):
             pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.4"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>", "GolemFactory <contact@golem.network>"]
 license = "LGPL-3.0-or-later"

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -427,6 +427,7 @@ class Executor(AsyncContextManager):
         find_offers_task = loop.create_task(find_offers())
         process_invoices_job = loop.create_task(process_invoices())
         wait_until_done = loop.create_task(work_queue.wait_until_done())
+        worker_starter_task = loop.create_task(worker_starter())
         # Py38: find_offers_task.set_name('find_offers_task')
 
         get_offers_deadline = datetime.now(timezone.utc) + self._conf.get_offers_timeout
@@ -437,6 +438,7 @@ class Executor(AsyncContextManager):
                 loop.create_task(worker_starter()),
                 process_invoices_job,
                 wait_until_done,
+                worker_starter_task,
             }
         )
 
@@ -490,6 +492,7 @@ class Executor(AsyncContextManager):
         finally:
 
             payment_closing = True
+            worker_starter_task.cancel()
             find_offers_task.cancel()
             try:
                 if workers:

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -5,6 +5,7 @@ import asyncio
 from asyncio import CancelledError
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+import logging
 import os
 import sys
 from typing import (
@@ -50,6 +51,8 @@ else:
 
 CFG_INVOICE_TIMEOUT: Final[timedelta] = timedelta(minutes=5)
 "Time to receive invoice from provider after tasks ended."
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -148,6 +151,7 @@ class Executor(AsyncContextManager):
             all_tasks = workers.union(services)
             for task in all_tasks:
                 if not task.done():
+                    logger.debug("Cancelling task: %s", task)
                     task.cancel()
             await asyncio.gather(*all_tasks, return_exceptions=True)
 
@@ -433,14 +437,9 @@ class Executor(AsyncContextManager):
         get_offers_deadline = datetime.now(timezone.utc) + self._conf.get_offers_timeout
         get_done_task: Optional[asyncio.Task] = None
         services.update(
-            {
-                find_offers_task,
-                loop.create_task(worker_starter()),
-                process_invoices_job,
-                wait_until_done,
-                worker_starter_task,
-            }
+            {find_offers_task, process_invoices_job, wait_until_done, worker_starter_task,}
         )
+        cancelled = False
 
         try:
             while wait_until_done in services or not done_queue.empty():
@@ -488,29 +487,48 @@ class Executor(AsyncContextManager):
 
         except (Exception, CancelledError, KeyboardInterrupt) as e:
             emit(events.ComputationFinished(exc_info=sys.exc_info()))  # type: ignore
+            cancelled = True
 
         finally:
 
+            # When cancelled emit logs with higher priority, so e.g. after
+            # hitting Ctrl+C the user sees shutdown progress on the console
+            log_level = logging.INFO if cancelled else logging.DEBUG
             payment_closing = True
-            worker_starter_task.cancel()
-            find_offers_task.cancel()
+            for task in services:
+                if task is not process_invoices_job:
+                    task.cancel()
+            if cancelled:
+                for worker_task in workers:
+                    worker_task.cancel()
+
+            if workers:
+                logger.log(log_level, "Waiting for %d workers to finish...", len(workers))
+                await asyncio.wait(
+                    workers.union(services), timeout=10, return_when=asyncio.ALL_COMPLETED
+                )
             try:
-                if workers:
-                    for worker_task in workers:
-                        worker_task.cancel()
-                    await asyncio.wait(workers, timeout=15, return_when=asyncio.ALL_COMPLETED)
+                logger.log(log_level, "Waiting for all services to finish...")
+                _, pending = await asyncio.wait(
+                    workers.union(services), timeout=10, return_when=asyncio.ALL_COMPLETED
+                )
+                if pending:
+                    logger.debug("Services still running: %s", pending)
             except Exception:
                 if self._conf.traceback:
                     traceback.print_exc()
-            await asyncio.wait(
-                workers.union({find_offers_task, process_invoices_job}),
-                timeout=5,
-                return_when=asyncio.ALL_COMPLETED,
-            )
+
             if agreements_to_pay:
-                await asyncio.wait(
-                    {process_invoices_job}, timeout=15, return_when=asyncio.ALL_COMPLETED
+                logger.log(
+                    log_level,
+                    "%d agreements still unpaid, waiting for invoices...",
+                    len(agreements_to_pay),
                 )
+                await asyncio.wait(
+                    {process_invoices_job}, timeout=10, return_when=asyncio.ALL_COMPLETED
+                )
+                if agreements_to_pay:
+                    logger.debug("Unpaid agreements  %s", agreements_to_pay)
 
     async def _create_allocations(self) -> rest.payment.MarketDecoration:
         if not self._budget_allocations:
@@ -584,3 +602,5 @@ class Executor(AsyncContextManager):
             emit(events.ShutdownFinished())
         except Exception:
             emit(events.ShutdownFinished(exc_info=sys.exc_info()))
+        finally:
+            await self._wrapped_consumer.stop()

--- a/yapapi/rest/activity.py
+++ b/yapapi/rest/activity.py
@@ -84,35 +84,26 @@ class Activity(AsyncContextManager["Activity"]):
         # on destroy_activity event.
         if exc_type:
             _log.debug(
-                "activity %s CLOSE for [%s] %s",
-                self._id,
-                exc_type.__name__,
-                exc_val,
-                exc_info=(exc_type, exc_val, exc_tb),
+                "Closing activity %s on error:", self._id, exc_info=(exc_type, exc_val, exc_tb)
             )
+        else:
+            _log.debug("Closing activity %s", self._id)
         try:
             batch_id = await self._api.call_exec(
                 self._id, yaa.ExeScriptRequest(text='[{"terminate":{}}]')
             )
-            with contextlib.suppress(yexc.ApiException, asyncio.TimeoutError):
+            with contextlib.suppress(asyncio.TimeoutError):
                 # wait 1sec before kill
-                await self._api.get_exec_batch_results(self._id, batch_id, timeout=1.0)
-        except yexc.ApiException as err:
-            # Suppress errors that say that this activity does not exist (we're closing it anyway).
-            msg_to_suppress = (
-                f"No service registered under given address '/public/exeunit/{self._id}/Exec'"
-            )
-            level = (
-                logging.ERROR
-                if err.status != 500 or msg_to_suppress not in err.body
-                else logging.DEBUG
-            )
-            _log.log(level, "failed to destroy activity: %s", self._id, exc_info=True)
+                await asyncio.wait_for(
+                    self._api.get_exec_batch_results(self._id, batch_id, timeout=1.0), timeout=1.0
+                )
+        except:
+            _log.debug("Failed to terminate activity gracefully: %s", self._id, exc_info=True)
         finally:
             with contextlib.suppress(yexc.ApiException):
+                _log.debug("Destroying activity %s...", self._id)
                 await self._api.destroy_activity(self._id)
-            if exc_type:
-                _log.debug("activity %s CLOSE done", self._id)
+            _log.debug("Activity %s closed", self._id)
 
 
 @dataclass


### PR DESCRIPTION
Resolves #141
Resolves #145 

Changes:
* Enforcing 1s timeout when closing an activity (previously waited 15s for the provider to respond to "terminate" command)
* Simplified computation shutdown sequence in `Executor.submit()`
* Added logging to `Executor`