### PR TITLE
Ensure no output before run, skip kernel test

### DIFF
--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -67,8 +67,9 @@ async def main(args):
 
             # Commands to be run on the provider
             commands = (
+                "rm /golem/work/hashcat.potfile || true; "
                 "touch /golem/work/hashcat.potfile; "
-                f"hashcat -a 3 -m 400 /golem/work/in.hash --skip {skip} --limit {limit} {args.mask} -o /golem/work/hashcat.potfile"
+                f"hashcat -a 3 -m 400 /golem/work/in.hash {args.mask} --skip={skip} --limit={limit} --self-test-disable -o /golem/work/hashcat.potfile || true"
             )
             ctx.run(f"/bin/sh", "-c", commands)
 


### PR DESCRIPTION
- Skipping OpenCL kernel test for quick computations 
- Clear potfiles before starting computations, so if all tasks are computed in one provider, the result won't be re-send for non-resulted tasks.