### PR TITLE
Fixes for "This event loop is already running" and for printing total cost

### DIFF
--- a/yapapi/executor/utils.py
+++ b/yapapi/executor/utils.py
@@ -42,9 +42,6 @@ class AsyncWrapper:
             await asyncio.gather(self._task, return_exceptions=True)
             self._task = None
 
-    def __del__(self):
-        self._loop.run_until_complete(self.stop())
-
     def async_call(self, *args, **kwargs) -> None:
         """Schedule an asynchronous call to the wrapped callable."""
         if not self._task:

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -260,10 +260,17 @@ class SummaryLogger:
 
         self._wrapped_emitter = wrapped_emitter
         self.numbers: Iterator[int] = itertools.count(1)
+        self.provider_cost = {}
         self._reset()
 
     def _reset(self) -> None:
-        """Reset all information aggregated by this logger."""
+        """Reset all information aggregated by this logger related to a single computation.
+
+        Here "computation" means an interval of time between the events
+        `ComputationStarted` and `ComputationFinished`.
+
+        Note that the `provider_cost` is not reset here, it is zeroed on `ExecutorShutdown`.
+        """
 
         self.start_time = time.time()
         self.received_proposals = {}
@@ -272,7 +279,6 @@ class SummaryLogger:
         self.confirmed_agreements = set()
         self.task_data = {}
         self.provider_tasks = defaultdict(list)
-        self.provider_cost = {}
         self.provider_failures = Counter()
         self.cancelled = False
         self.finished = False
@@ -300,11 +306,12 @@ class SummaryLogger:
         for provider_name, count in self.provider_failures.items():
             self.logger.info("Activity failed %d time(s) on provider '%s'", count, provider_name)
 
-    def _print_total_cost(self) -> None:
+    def _print_total_cost(self, partial: bool = False) -> None:
         """Print the sum of all accepted invoices."""
 
         total_cost = sum(self.provider_cost.values(), 0.0)
-        self.logger.info("Total cost: %s", total_cost)
+        label = "Total cost" if not partial else "The cost so far"
+        self.logger.info("%s: %s", label, total_cost)
 
     def log(self, event: events.Event) -> None:
         """Register an event."""
@@ -324,6 +331,9 @@ class SummaryLogger:
     def _handle(self, event: events.Event):
         if isinstance(event, events.ComputationStarted):
             self._reset()
+            if self.provider_cost:
+                # This means another computation run in the current Executor instance.
+                self._print_total_cost(partial=True)
 
         if isinstance(event, events.SubscriptionCreated):
             self.logger.info(event_type_to_string[type(event)])
@@ -429,6 +439,7 @@ class SummaryLogger:
 
         elif isinstance(event, events.ShutdownFinished):
             self._print_total_cost()
+            self.provider_cost = {}
             if not event.exc_info:
                 total_time = time.time() - self.start_time
                 self.logger.info(f"Executor shut down, total time: {total_time:.1f}s")


### PR DESCRIPTION
Resolves #149 
Resolves #151 

* "Total cost" is now printed unconditionally when SummaryLogger gets `ExecutorShutdown` event, and only then. This ensures that all invoices are included and that the cost is printed exactly once. Previously it was more complicated, the cost could be printed on either `ComputationFinished` or `PaymentAccepted`, under some conditions (expressed as obscure `issubsetof` check) that sometimes led to the cost being printed more than once, or not at all (in rare cases).

* In case a single `Executor` instance performs more than one computation (`submit()` is called more than once), cummulative partial cost is printed after each computation except the last one (total cost is still printed after the last one at executor shutdown). For example in `yacat.py`:
```
[2020-11-27 16:31:57,932 INFO yapapi.summary] Computation finished in 11.4s
[2020-11-27 16:31:57,932 INFO yapapi.summary] Negotiated 3 agreements with 3 providers
[2020-11-27 16:31:57,932 INFO yapapi.summary] Provider 'eniac.3' computed 1 tasks
[2020-11-27 16:31:57,932 INFO yapapi.summary] Provider 'manchester.3' did not compute any tasks
[2020-11-27 16:31:57,933 INFO yapapi.summary] Provider 'ada' did not compute any tasks
Task computed: keyspace size count. The keyspace size is 9025
[2020-11-27 16:32:01,148 INFO yapapi.summary] The cost so far: 0.01683696749872222
[2020-11-27 16:32:01,413 INFO yapapi.summary] Demand published on the market
[2020-11-27 16:32:03,797 INFO yapapi.summary] Received proposals from 1 providers so far
...
[2020-11-27 16:32:22,093 INFO yapapi.summary] Computation finished in 20.9s
[2020-11-27 16:32:22,093 INFO yapapi.summary] Negotiated 3 agreements with 3 providers
[2020-11-27 16:32:22,094 INFO yapapi.summary] Provider 'univac.3' computed 1 tasks
[2020-11-27 16:32:22,094 INFO yapapi.summary] Provider 'odra.3' computed 1 tasks
[2020-11-27 16:32:22,094 INFO yapapi.summary] Provider 'eniac.3' computed 1 tasks
Password found: pas
[2020-11-27 16:32:24,983 INFO yapapi.summary] Total cost: 0.11014212215272223
[2020-11-27 16:32:24,983 INFO yapapi.summary] Executor shut down, total time: 23.8s  
```

* A `__del__()` method is removed from `yapapi.executor.utils.AsyncWrapper`. It caused occasional problems with the asyncio event loop (the method was probably buggy). The `AsyncWrapper` instance is used only in `Executor` and is stopped explicitly in `Executor`'s `__aexit__()` method anyway, so we don't need a destructor for it. 