### PR TITLE
Don't start new agreement if there are no tasks available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ python = "^3.6.1"
 aiohttp = "^3.6"
 aiohttp-sse-client = "^0.1.7"
 dataclasses = { version = "^0.7", python = ">=3.6, <3.7"}
-
+more-itertools = "^8.6.0"
 urllib3 = "^1.25.9"
 typing_extensions = "^3.7.4"
 

--- a/tests/executor/test_smartq.py
+++ b/tests/executor/test_smartq.py
@@ -7,8 +7,9 @@ import asyncio
 
 
 @pytest.mark.asyncio
-async def test_smart_queue():
-    q = SmartQueue(range(50))
+@pytest.mark.parametrize("length", [0, 1, 100])
+async def test_smart_queue(length: int):
+    q = SmartQueue(range(length))
 
     async def worker(i, queue):
         print(f"worker {i} started")

--- a/tests/executor/test_smartq.py
+++ b/tests/executor/test_smartq.py
@@ -53,6 +53,21 @@ async def test_smart_queue_empty():
 
 
 @pytest.mark.asyncio
+async def test_unassigned_items():
+    q = SmartQueue([1, 2, 3])
+    with q.new_consumer() as c:
+        async for handle in c:
+            assert q.has_new_items() == q.has_unassigned_items()
+            if not q.has_unassigned_items():
+                assert handle.data == 3
+                break
+        assert not q.has_unassigned_items()
+        await q.reschedule_all(c)
+        assert q.has_unassigned_items()
+        assert not q.has_new_items()
+
+
+@pytest.mark.asyncio
 async def test_smart_queue_retry(caplog):
     loop = asyncio.get_event_loop()
 

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -405,7 +405,11 @@ class Executor(AsyncContextManager):
         async def worker_starter() -> None:
             while True:
                 await asyncio.sleep(2)
-                if offer_buffer and len(workers) < self._conf.max_workers:
+                if (
+                    offer_buffer
+                    and len(workers) < self._conf.max_workers
+                    and work_queue.has_unassigned_items()
+                ):
                     provider_id, b = random.choice(list(offer_buffer.items()))
                     del offer_buffer[provider_id]
                     new_task = None

--- a/yapapi/executor/_smartq.py
+++ b/yapapi/executor/_smartq.py
@@ -80,8 +80,8 @@ class SmartQueue(Generic[Item], object):
     def new_consumer(self) -> "Consumer[Item]":
         return Consumer(self)
 
-    def __have_data(self):
-        return self._items is not None or bool(self._rescheduled_items) or bool(self._in_progress)
+    def __has_data(self):
+        return self.has_new_items() or bool(self._rescheduled_items) or bool(self._in_progress)
 
     def __find_rescheduled_item(self, consumer: "Consumer[Item]") -> Optional[Handle[Item]]:
         return next(
@@ -95,7 +95,7 @@ class SmartQueue(Generic[Item], object):
 
     async def get(self, consumer: "Consumer[Item]") -> Handle[Item]:
         async with self._lock:
-            while self.__have_data():
+            while self.__has_data():
                 handle = self.__find_rescheduled_item(consumer)
                 if handle:
                     self._rescheduled_items.remove(handle)
@@ -153,7 +153,7 @@ class SmartQueue(Generic[Item], object):
 
     async def wait_until_done(self) -> None:
         async with self._lock:
-            while self.__have_data():
+            while self.__has_data():
                 await self._eof.wait()
 
 

--- a/yapapi/executor/utils.py
+++ b/yapapi/executor/utils.py
@@ -1,10 +1,6 @@
 """Utility functions and classes used within the `yapapi.executor` package."""
 import asyncio
-import logging
 from typing import Callable, Optional
-
-
-logger = logging.getLogger(__name__)
 
 
 class AsyncWrapper:
@@ -34,15 +30,10 @@ class AsyncWrapper:
         self._task = self._loop.create_task(self._worker())
 
     async def _worker(self) -> None:
-        try:
-            while True:
-                (args, kwargs) = await self._args_buffer.get()
-                self._wrapped(*args, **kwargs)
-                self._args_buffer.task_done()
-        except (asyncio.CancelledError, KeyboardInterrupt):
-            logger.debug("Worker task interrupted", exc_info=True)
-        except Exception:
-            logger.debug("Unexpected error in worker task", exc_info=True)
+        while True:
+            (args, kwargs) = await self._args_buffer.get()
+            self._wrapped(*args, **kwargs)
+            self._args_buffer.task_done()
 
     async def stop(self) -> None:
         await self._args_buffer.join()
@@ -50,7 +41,6 @@ class AsyncWrapper:
             self._task.cancel()
             await asyncio.gather(self._task, return_exceptions=True)
             self._task = None
-            logger.debug("AsyncWrapper stopped")
 
     def async_call(self, *args, **kwargs) -> None:
         """Schedule an asynchronous call to the wrapped callable."""


### PR DESCRIPTION
Resolves #156 
Resolves #165 
Resolves #143 

**Note** The PR links agreement creation with the availability of tasks (items in the `tasks` parameter for the worker functions). ~~This adds new constraints on how the workers should be written. Previously, a developer could create a worker that does some work on the providers without consuming any tasks. With the changes introduced in this PR, the following worker would not start, if given empty `tasks` argument:~~
```
def worker(ctx, tasks):
    ctx.run("/bin/sh", "-c", "echo hello world\! > hello.txt")
    ctx.download_file("hello.txt", "output.txt")
    ctx.yield()
```

[EDIT] I've just realised my remark above is not valid: a worker **should not** execute any commands given an empty list of tasks, because it should not be instantiated at all. The fact that it currently **does work** in `yapapi` is obviously a bug (see https://github.com/golemfactory/yapapi/issues/165), not a feature that we want to keep. The rest below still holds, although it's less important. [/EDIT]
 
With a non-empty `tasks` argument, for example a singleton list, the number of agreements will still be bounded only by `max_workers` argument to `Executor` (since no tasks are ever consumed, they will always be available). 

It's also still possible to start excessive agreements, for example the following scenario is possible for a computation with a single task:
1) Agreement 1 is created, activity and a worker is started for this agreement
2) The worker yields control before consuming a task (e.g. waits for I/O with `asyncio` or just goes to sleep for a few seconds)
3) The task is still available, so Agreement 2 is created
4) One of the workers finally gets the task and computes is
5) Computation finishes, only one of the agreements is used to compute the task

For example, this happened after inserting 5s sleep at the beginning of the first worker function in `yacat.py` (before iterating over tasks):
```
[2020-12-01 01:05:24,952 INFO yapapi.summary] Received proposals from 10 providers so far
[2020-12-01 01:05:26,414 INFO yapapi.summary] Agreement proposed to provider 'ADA_ADA_ADA_ADA_ADA'
[2020-12-01 01:05:26,652 INFO yapapi.summary] Received proposals from 11 providers so far
[2020-12-01 01:05:27,660 INFO yapapi.summary] Agreement confirmed by provider 'ADA_ADA_ADA_ADA_ADA'
[2020-12-01 01:05:29,678 INFO yapapi.summary] Agreement proposed to provider 'friendly-error'
[2020-12-01 01:05:29,841 INFO yapapi.summary] Agreement confirmed by provider 'friendly-error'
[2020-12-01 01:05:31,851 INFO yapapi.summary] Agreement proposed to provider 'collossus.3'
[2020-12-01 01:05:31,989 INFO yapapi.summary] Agreement confirmed by provider 'collossus.3'
[2020-12-01 01:05:34,989 INFO yapapi.summary] Task sent to provider 'ADA_ADA_ADA_ADA_ADA', task data: None
[2020-12-01 01:05:39,176 INFO yapapi.summary] Task computed by provider 'ADA_ADA_ADA_ADA_ADA', task data: None
[2020-12-01 01:05:39,187 INFO yapapi.summary] Computation finished in 17.0s
[2020-12-01 01:05:39,188 INFO yapapi.summary] Negotiated 3 agreements with 3 providers
[2020-12-01 01:05:39,188 INFO yapapi.summary] Provider 'ADA_ADA_ADA_ADA_ADA' computed 1 tasks
[2020-12-01 01:05:39,188 INFO yapapi.summary] Provider 'collossus.3' did not compute any tasks
[2020-12-01 01:05:39,188 INFO yapapi.summary] Provider 'friendly-error' did not compute any tasks
```

However, such situations are much less likely after this change. Without such modification `yacat.py` runs as follows:
```
[2020-12-01 01:09:12,774 INFO yapapi.summary] Received proposals from 8 providers so far
[2020-12-01 01:09:12,787 INFO yapapi.summary] Agreement proposed to provider 'ferranti.3'
[2020-12-01 01:09:12,799 INFO yapapi.summary] Received proposals from 9 providers so far
[2020-12-01 01:09:12,873 INFO yapapi.summary] Received proposals from 10 providers so far
[2020-12-01 01:09:13,466 INFO yapapi.summary] Received proposals from 11 providers so far
[2020-12-01 01:09:16,702 INFO yapapi.summary] Agreement confirmed by provider 'ferranti.3'
[2020-12-01 01:09:17,732 INFO yapapi.summary] Task sent to provider 'ferranti.3', task data: None
[2020-12-01 01:09:21,913 INFO yapapi.summary] Task computed by provider 'ferranti.3', task data: None
[2020-12-01 01:09:21,917 INFO yapapi.summary] Computation finished in 11.3s
[2020-12-01 01:09:21,918 INFO yapapi.summary] Negotiated 1 agreements with 1 providers
[2020-12-01 01:09:21,918 INFO yapapi.summary] Provider 'ferranti.3' computed 1 tasks
```

[UPDATE] changes in https://github.com/golemfactory/yapapi/pull/162/commits/bb65b7528ee9994fac2f17e738409c92c9f65fb8 make the executor exit if it's given an empty list of tasks (see #165).

[UPDATE] changes in https://github.com/golemfactory/yapapi/pull/162/commits/851597f01104d8cbb57b50a3faf92fbd1a9b68ff make the executor shut down without waiting for invoices when user hits ctrl+c and no activities have been started (see #143).