### PR TITLE
Don't suppress CancelledError in worker_starter (and other coroutines)

### DIFF
--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -229,7 +229,7 @@ class Executor(AsyncContextManager):
                         await invoice.accept(amount=invoice.amount, allocation=allocation)
                     except CancelledError:
                         raise
-                    except Exception as e:
+                    except Exception:
                         emit(
                             events.PaymentFailed(
                                 agr_id=invoice.agreement_id, exc_info=sys.exc_info()  # type: ignore

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -227,7 +227,9 @@ class Executor(AsyncContextManager):
                     allocation = self._allocation_for_invoice(invoice)
                     try:
                         await invoice.accept(amount=invoice.amount, allocation=allocation)
-                    except Exception:
+                    except CancelledError:
+                        raise
+                    except Exception as e:
                         emit(
                             events.PaymentFailed(
                                 agr_id=invoice.agreement_id, exc_info=sys.exc_info()  # type: ignore
@@ -307,6 +309,8 @@ class Executor(AsyncContextManager):
                                 )
                             await proposal.respond(builder.properties, builder.constraints)
                             emit(events.ProposalResponded(prop_id=proposal.id))
+                        except CancelledError:
+                            raise
                         except Exception as ex:
                             emit(events.ProposalFailed(prop_id=proposal.id, reason=str(ex)))
                     else:
@@ -426,13 +430,12 @@ class Executor(AsyncContextManager):
                         agreements_confirmed += 1
                         new_task = loop.create_task(start_worker(agreement))
                         workers.add(new_task)
-                        # task.add_done_callback(on_worker_stop)
+                    except CancelledError:
+                        raise
                     except Exception as e:
                         if new_task:
                             new_task.cancel()
                         emit(events.ProposalFailed(prop_id=b.proposal.id, reason=str(e)))
-                    finally:
-                        pass
 
         loop = asyncio.get_event_loop()
         find_offers_task = loop.create_task(find_offers())
@@ -492,7 +495,7 @@ class Executor(AsyncContextManager):
 
             emit(events.ComputationFinished())
 
-        except (Exception, CancelledError, KeyboardInterrupt) as e:
+        except (Exception, CancelledError, KeyboardInterrupt):
             emit(events.ComputationFinished(exc_info=sys.exc_info()))  # type: ignore
             cancelled = True
 


### PR DESCRIPTION
Resolves #150 
Resolves #170 


Prior to Python 3.8, `asyncio.CancelledError` was a subclass of `Exception`, so the `except Exception` clause in `worker_starter` prevents the coroutine from being cancelled if `yapapi` is run with Python 3.6 or 3.7: https://github.com/golemfactory/yapapi/blob/6b19bd93bbb27573f7b21d2a28b7d6dddc0f2970/yapapi/executor/__init__.py#L388-L391

Our intention is for the coroutines to be cancellable. The fix is to re-raise `CancelledError`:
```python
except CancelledError:
    raise
except Exception as e:
    if new_task:
        new_task.cancel()
    emit(events.ProposalFailed(prop_id=proposal.id, reason=str(e)))
``