### PR TITLE
Emit warning from summary logger if computation timeout is outside 5--30 min range

### DIFF
--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -170,7 +170,7 @@ class Executor(AsyncContextManager):
 
         multi_payment_decoration = await self._create_allocations()
 
-        emit(events.ComputationStarted())
+        emit(events.ComputationStarted(self._expires))
 
         # Building offer
         builder = DemandBuilder()

--- a/yapapi/executor/events.py
+++ b/yapapi/executor/events.py
@@ -1,6 +1,6 @@
 """Representing events in Golem computation."""
 import dataclasses
-from datetime import timedelta
+from datetime import datetime, timedelta
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Any, Optional, Type, Tuple, List
@@ -42,7 +42,7 @@ class HasExcInfo(Event):
 
 @dataclass
 class ComputationStarted(Event):
-    pass
+    expires: datetime
 
 
 @dataclass


### PR DESCRIPTION
Resolves #167

See also: #174 

This PR adds printing a warning message in summary logger if the timeout for the whole computation is set outside of 5--30 min range. It also mentions the timeout when printing warning after no responses from providers have been received for some time:
```
[2020-12-08 08:06:08,161 INFO yapapi.executor] Using log file `blender-yapapi.log`; in case of errors look for additional information there
yapapi version: 0.4.1-alpha.0
Using subnet: community.3
[2020-12-08 08:06:08,735 WARNING yapapi.summary] Expiration time for your tasks is set to 4 min 59 sec from now. Providers will probably not respond to tasks which expire sooner than 5 min or later than 30 min, counting from the moment they get your demand. Use the `timeout` parameter to `Executor()` to adjust the timeout.
[2020-12-08 08:06:08,949 INFO yapapi.summary] Demand published on the market
[2020-12-08 08:06:28,942 WARNING yapapi.summary] 37 offers have been collected from the market, but no provider has responded for 20s. Make sure you're using the latest released versions of yagna and yapapi, and the correct subnet. Also make sure that the timeout for computing all tasks is within the 5 min to 30 min range.
```