### PR TITLE
Don't send terminate command to exe unit before destroying activity

### DIFF
--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -339,6 +339,7 @@ class Executor(AsyncContextManager):
                         agr_id=agreement.id, exc_info=sys.exc_info()  # type: ignore
                     )
                 )
+                emit(events.WorkerFinished(agr_id=agreement.id))
                 raise
             async with act:
                 emit(events.ActivityCreated(act_id=act.id, agr_id=agreement.id))

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -508,18 +508,18 @@ class Executor(AsyncContextManager):
                     "golem.requestor.code": "Success",
                 }
 
+            if workers:
+                logger.log(log_level, "Waiting for %d workers to finish...", len(workers))
+                await asyncio.wait(
+                    workers.union(services), timeout=10, return_when=asyncio.ALL_COMPLETED
+                )
+
             try:
                 await agreements_pool.terminate(reason=reason)
             except Exception:
                 logger.debug("Problem with agreements termination", exc_info=True)
                 if self._conf.traceback:
                     traceback.print_exc()
-
-            if workers:
-                logger.log(log_level, "Waiting for %d workers to finish...", len(workers))
-                await asyncio.wait(
-                    workers.union(services), timeout=10, return_when=asyncio.ALL_COMPLETED
-                )
 
             try:
                 logger.log(log_level, "Waiting for all services to finish...")
@@ -539,10 +539,10 @@ class Executor(AsyncContextManager):
                     len(agreements_to_pay),
                 )
                 await asyncio.wait(
-                    {process_invoices_job}, timeout=10, return_when=asyncio.ALL_COMPLETED
+                    {process_invoices_job}, timeout=20, return_when=asyncio.ALL_COMPLETED
                 )
                 if agreements_to_pay:
-                    logger.debug("Unpaid agreements  %s", agreements_to_pay)
+                    logger.warning("Unpaid agreements  %s", agreements_to_pay)
 
     async def _create_allocations(self) -> rest.payment.MarketDecoration:
         if not self._budget_allocations:

--- a/yapapi/rest/activity.py
+++ b/yapapi/rest/activity.py
@@ -40,12 +40,8 @@ class ActivityService(object):
                  and allows to query and control its state
         :rtype: Activity
         """
-        try:
-            activity_id = await self._api.create_activity(agreement_id)
-            return Activity(self._api, self._state, activity_id)
-        except yexc.ApiException:
-            _log.debug("Failed to create activity for agreement %s", agreement_id, exc_info=True)
-            raise
+        activity_id = await self._api.create_activity(agreement_id)
+        return Activity(self._api, self._state, activity_id)
 
 
 class Activity(AsyncContextManager["Activity"]):

--- a/yapapi/rest/activity.py
+++ b/yapapi/rest/activity.py
@@ -44,7 +44,7 @@ class ActivityService(object):
             activity_id = await self._api.create_activity(agreement_id)
             return Activity(self._api, self._state, activity_id)
         except yexc.ApiException:
-            _log.error("Failed to create activity for agreement %s", agreement_id)
+            _log.debug("Failed to create activity for agreement %s", agreement_id, exc_info=True)
             raise
 
 
@@ -80,27 +80,18 @@ class Activity(AsyncContextManager["Activity"]):
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        # w/o for some buggy providers which do not kill exe-unit
-        # on destroy_activity event.
+        """Call DestroyActivity API operation."""
         if exc_type:
             _log.debug(
-                "Closing activity %s on error:", self._id, exc_info=(exc_type, exc_val, exc_tb)
+                "Destroying activity %s on error:", self._id, exc_info=(exc_type, exc_val, exc_tb)
             )
         else:
-            _log.debug("Closing activity %s", self._id)
+            _log.debug("Destroying activity %s", self._id)
         try:
-            deadline = datetime.now(timezone.utc) + timedelta(seconds=10)
-            batch = await self.send(script=[{"terminate": {}}], stream=True, deadline=deadline)
-            async for evt_ctx in batch:
-                _log.debug("Command output for 'terminate': %r", evt_ctx)
-            _log.debug("Successfully terminated activity %s", self._id)
-        except:
-            _log.debug("Failed to terminate activity gracefully: %s", self._id, exc_info=True)
-        finally:
-            with contextlib.suppress(yexc.ApiException):
-                _log.debug("Destroying activity %s...", self._id)
-                await self._api.destroy_activity(self._id)
-            _log.debug("Activity %s closed", self._id)
+            await self._api.destroy_activity(self._id)
+            _log.debug("Activity %s destroyed successfully", self._id)
+        except yexc.ApiException:
+            _log.debug("Got API Exception when destroying activity %s", self._id, exc_info=True)
 
 
 @dataclass


### PR DESCRIPTION
Currently, before an activity is destroyed (by calling `DestroyActivity` API operation), the "terminate" command is sent to the exe unit. This is supposedly a "w/a for some buggy providers which do not kill exe-unit on destroy_activity event.", see https://github.com/golemfactory/yapapi/blob/d02f3825bdd8b53410c6512a85f5ae136d59528a/yapapi/rest/activity.py#L83-L103

However, I probably have never seen this "terminate" command executed successfully, it usually either times out (when the timeout was set to 1-2s in previous versions of code) or gets `CancelledError` from `AgreementsPool.terminate_agreement()` which terminates the agreement to which this activity belongs. 

Either way, sending "terminate" does not achieve anything and we get spurious error messages in the debug log, and occasionally, a warning message about "unclosed client session" from `aiohttp` in the console (this sometimes happens when `Activity.__aexit__()` gets `CancelledError`):
```
[2021-01-13 20:29:00,822 INFO yapapi.summary] Computation finished in 39.1s
[2021-01-13 20:29:00,822 INFO yapapi.summary] Negotiated 4 agreements with 4 providers
[2021-01-13 20:29:00,823 INFO yapapi.summary] Provider 'witek.4' computed 4 tasks
[2021-01-13 20:29:00,823 INFO yapapi.summary] Provider '2rec-ubuntu.4' computed 3 tasks
[2021-01-13 20:29:00,823 INFO yapapi.summary] Provider 'mbenke.4' computed 3 tasks
[2021-01-13 20:29:00,823 INFO yapapi.summary] Provider 'michal.4' computed 2 tasks
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7f225225e040>
```

The present PR therefore removes the API call that sends "terminate" altogether.