### PR TITLE
Set `ya-aioclient=0.4.1` in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ rich = { version = "^2.2.5", optional = true }
 async_exit_stack = "^1.0.1"
 jsonrpc-base = "^1.0.3"
 
-ya-aioclient = "^0.4.0"
+ya-aioclient = "0.4.1"
 toml = "^0.10.1"
 srvresolver = "^0.3.5"
 


### PR DESCRIPTION
The dependency specification is currently `ya-aioclient=^0.4.0`, but `ya-aioclient-0.4.2` is unfortunately not backward-compatible.

EDIT: this is a temporary measure, we'll update to `ya-aioclient="^0.5.0"` soon. 