### PR TITLE
Select payment platforms based on driver/network specification

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -6,6 +6,7 @@ import sys
 
 from yapapi import (
     Executor,
+    NoPaymentAccountError,
     Task,
     __version__ as yapapi_version,
     WorkContext,
@@ -27,7 +28,7 @@ from examples.utils import (
 script_dir = pathlib.Path(__file__).resolve().parent
 
 
-async def main(subnet_tag):
+async def main(subnet_tag, driver=None, network=None):
     package = await vm.repo(
         image_hash="9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
         min_mem_gib=0.5,
@@ -96,6 +97,8 @@ async def main(subnet_tag):
         budget=10.0,
         timeout=timeout,
         subnet_tag=subnet_tag,
+        driver=driver,
+        network=network,
         event_consumer=log_summary(log_event_repr),
     ) as executor:
 
@@ -131,6 +134,13 @@ if __name__ == "__main__":
 
     try:
         loop.run_until_complete(task)
+    except NoPaymentAccountError as e:
+        print(
+            f"{TEXT_COLOR_RED}"
+            f"No payment account initialized for driver `{e.required_driver}` "
+            f"and network `{e.required_network}`. Did you run `yagna payment init -r`?"
+            f"{TEXT_COLOR_DEFAULT}"
+        )
     except KeyboardInterrupt:
         print(
             f"{TEXT_COLOR_YELLOW}"

--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -25,9 +25,6 @@ from examples.utils import (
 )
 
 
-script_dir = pathlib.Path(__file__).resolve().parent
-
-
 async def main(subnet_tag, driver=None, network=None):
     package = await vm.repo(
         image_hash="9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
@@ -36,6 +33,7 @@ async def main(subnet_tag, driver=None, network=None):
     )
 
     async def worker(ctx: WorkContext, tasks):
+        script_dir = pathlib.Path(__file__).resolve().parent
         scene_path = str(script_dir / "cubes.blend")
         ctx.send_file(scene_path, "/golem/resource/scene.blend")
         async for task in tasks:
@@ -102,6 +100,13 @@ async def main(subnet_tag, driver=None, network=None):
         event_consumer=log_summary(log_event_repr),
     ) as executor:
 
+        sys.stderr.write(
+            f"yapapi version: {TEXT_COLOR_YELLOW}{yapapi_version}{TEXT_COLOR_DEFAULT}\n"
+            f"Using subnet: {TEXT_COLOR_YELLOW}{subnet_tag}{TEXT_COLOR_DEFAULT}, "
+            f"payment driver: {TEXT_COLOR_YELLOW}{executor.driver}{TEXT_COLOR_DEFAULT}, "
+            f"and network: {TEXT_COLOR_YELLOW}{executor.network}{TEXT_COLOR_DEFAULT}\n"
+        )
+
         async for task in executor.submit(worker, [Task(data=frame) for frame in frames]):
             print(
                 f"{TEXT_COLOR_CYAN}"
@@ -126,11 +131,9 @@ if __name__ == "__main__":
     )
 
     loop = asyncio.get_event_loop()
-
-    subnet = args.subnet_tag
-    sys.stderr.write(f"yapapi version: {TEXT_COLOR_YELLOW}{yapapi_version}{TEXT_COLOR_DEFAULT}\n")
-    sys.stderr.write(f"Using subnet: {TEXT_COLOR_YELLOW}{subnet}{TEXT_COLOR_DEFAULT}\n")
-    task = loop.create_task(main(subnet_tag=args.subnet_tag))
+    task = loop.create_task(
+        main(subnet_tag=args.subnet_tag, driver=args.driver, network=args.network)
+    )
 
     try:
         loop.run_until_complete(task)
@@ -152,9 +155,7 @@ if __name__ == "__main__":
         try:
             loop.run_until_complete(task)
             print(
-                f"{TEXT_COLOR_YELLOW}"
-                "Shutdown completed, thank you for waiting!"
-                f"{TEXT_COLOR_DEFAULT}"
+                f"{TEXT_COLOR_YELLOW}Shutdown completed, thank you for waiting!{TEXT_COLOR_DEFAULT}"
             )
         except (asyncio.CancelledError, KeyboardInterrupt):
             pass

--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -116,7 +116,7 @@ async def main(subnet_tag, driver=None, network=None):
 
 
 if __name__ == "__main__":
-    parser = build_parser("Render blender scene")
+    parser = build_parser("Render a Blender scene")
     parser.set_defaults(log_file="blender-yapapi.log")
     args = parser.parse_args()
 

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -16,6 +16,8 @@ TEXT_COLOR_DEFAULT = "\033[0m"
 
 def build_parser(description: str):
     parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("--driver", help="Payment driver name, for example `zksync`")
+    parser.add_argument("--network", help="Network name, for example `rinkeby`")
     parser.add_argument(
         "--subnet-tag", default="community.3", help="Subnet name; default: %(default)s"
     )

--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -103,6 +103,12 @@ async def main(args):
         event_consumer=log_summary(log_event_repr),
     ) as executor:
 
+        sys.stderr.write(
+            f"Using subnet: {TEXT_COLOR_YELLOW}{args.subnet_tag}{TEXT_COLOR_DEFAULT}, "
+            f"payment driver: {TEXT_COLOR_YELLOW}{executor.driver}{TEXT_COLOR_DEFAULT}, "
+            f"and network: {TEXT_COLOR_YELLOW}{executor.network}{TEXT_COLOR_DEFAULT}\n"
+        )
+
         keyspace_computed = False
         # This is not a typical use of executor.submit as there is only one task, with no data:
         async for _task in executor.submit(worker_check_keyspace, [Task(data=None)]):
@@ -153,8 +159,6 @@ if __name__ == "__main__":
 
     enable_default_logger(log_file=args.log_file)
 
-    sys.stderr.write(f"Using subnet: {TEXT_COLOR_YELLOW}{args.subnet_tag}{TEXT_COLOR_DEFAULT}\n")
-
     loop = asyncio.get_event_loop()
     task = loop.create_task(main(args))
 
@@ -178,9 +182,7 @@ if __name__ == "__main__":
         try:
             loop.run_until_complete(task)
             print(
-                f"{TEXT_COLOR_YELLOW}"
-                "Shutdown completed, thank you for waiting!"
-                f"{TEXT_COLOR_DEFAULT}"
+                f"{TEXT_COLOR_YELLOW}Shutdown completed, thank you for waiting!{TEXT_COLOR_DEFAULT}"
             )
         except KeyboardInterrupt:
             pass

--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import pathlib
 import sys
 
-from yapapi import Executor, Task, WorkContext, windows_event_loop_fix
+from yapapi import Executor, NoPaymentAccountError, Task, WorkContext, windows_event_loop_fix
 from yapapi.log import enable_default_logger, log_summary, log_event_repr  # noqa
 from yapapi.package import vm
 
@@ -98,6 +98,8 @@ async def main(args):
         # timeout should be keyspace / number of providers dependent
         timeout=timedelta(minutes=10),
         subnet_tag=args.subnet_tag,
+        driver=args.driver,
+        network=args.network,
         event_consumer=log_summary(log_event_repr),
     ) as executor:
 
@@ -158,6 +160,13 @@ if __name__ == "__main__":
 
     try:
         loop.run_until_complete(task)
+    except NoPaymentAccountError as e:
+        print(
+            f"{TEXT_COLOR_RED}"
+            f"No payment account initialized for driver `{e.required_driver}` "
+            f"and network `{e.required_network}`. Did you run `yagna payment init -r`?"
+            f"{TEXT_COLOR_DEFAULT}"
+        )
     except KeyboardInterrupt:
         print(
             f"{TEXT_COLOR_YELLOW}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ poethepoet = "^0.8.0"
 pytest-cov = "^2.10.1"
 pydoc-markdown = "^3.5.0"
 factory-boy = "^3.2.0"
+asynctest = "^0.13.0"
 
 [tool.portray]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ poethepoet = "^0.8.0"
 pytest-cov = "^2.10.1"
 pydoc-markdown = "^3.5.0"
 factory-boy = "^3.2.0"
-asynctest = "^0.13.0"
 
 [tool.portray]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ rich = { version = "^2.2.5", optional = true }
 async_exit_stack = "^1.0.1"
 jsonrpc-base = "^1.0.3"
 
-ya-aioclient = "0.4.1"
+ya-aioclient = "^0.5.0"
 toml = "^0.10.1"
 srvresolver = "^0.3.5"
 

--- a/tests/executor/test_payment_platforms.py
+++ b/tests/executor/test_payment_platforms.py
@@ -2,10 +2,9 @@
 import os
 from unittest import mock
 
+import asynctest
 import pytest
-import ya_payment
 
-import yapapi
 from yapapi.executor import Executor, NoPaymentAccountError, DEFAULT_NETWORK, DEFAULT_DRIVER
 from yapapi.rest.payment import Account
 
@@ -15,65 +14,60 @@ def _set_app_key():
     os.environ["YAGNA_APPKEY"] = "mock-appkey"
 
 
-def _mock_account(driver: str, network: str, **kwargs) -> Account:
-    """Create mock `Account` instance."""
+def _mock_accounts_iterator(*account_specs):
+    """Create an iterator over mock `Account` objects.
 
-    params = {
-        "platform": "mock-platform",
-        "address": "mock-address",
-        "driver": driver,
-        "network": network,
-        "token": "mock-token",
-        "send": True,
-        "receive": True,
-    }
-    params.update(kwargs)
-    return Account(**params)
-
-
-def _mock_rest_accounts(accounts):
-    """Create mock for `Payment.accounts()`"""
+    `account_specs` should contain pairs `(driver, network)`, where `driver` and `network`
+    are strings, or triples `(driver, network, params)` with `driver` and `network` as before
+    and `params` a dictionary containing additional keyword arguments for `Account()`.
+    """
 
     async def _mock(*_args):
-        for a in accounts:
-            yield a
+        for spec in account_specs:
+            params = {
+                "platform": "mock-platform",
+                "address": "mock-address",
+                "driver": spec[0],
+                "network": spec[1],
+                "token": "mock-token",
+                "send": True,
+                "receive": True,
+            }
+            if len(spec) == 3:
+                params.update(**spec[2])
+            yield Account(**params)
 
     return _mock
 
 
 @pytest.mark.asyncio
-async def test_no_accounts_raises(monkeypatch):
+@mock.patch("yapapi.executor.rest.Payment.accounts", _mock_accounts_iterator())
+async def test_no_accounts_raises():
     """Test that exception is raised if `Payment.accounts()` returns empty list."""
 
-    monkeypatch.setattr(yapapi.executor.rest.Payment, "accounts", _mock_rest_accounts([]))
-
-    async with Executor(package=mock.MagicMock(), budget=10.0) as executor:
+    async with Executor(package=mock.Mock(), budget=10.0) as executor:
         with pytest.raises(NoPaymentAccountError):
-            async for _ in executor.submit(worker=mock.MagicMock(), data=mock.MagicMock()):
+            async for _ in executor.submit(worker=mock.Mock(), data=mock.Mock()):
                 pass
 
 
 @pytest.mark.asyncio
-async def test_no_matching_account_raises(monkeypatch):
+@mock.patch(
+    "yapapi.executor.rest.Payment.accounts",
+    _mock_accounts_iterator(
+        ("other-driver", "other-network"),
+        ("matching-driver", "other-network"),
+        ("other-driver", "matching-network"),
+    ),
+)
+async def test_no_matching_account_raises():
     """Test that exception is raised if `Payment.accounts()` returns no matching accounts."""
 
-    monkeypatch.setattr(
-        yapapi.executor.rest.Payment,
-        "accounts",
-        _mock_rest_accounts(
-            [
-                _mock_account("other-driver", "other-network"),
-                _mock_account("matching-driver", "other-network"),
-                _mock_account("other-driver", "matching-network"),
-            ]
-        ),
-    )
-
     async with Executor(
-        package=mock.MagicMock(), budget=10.0, driver="matching-driver", network="matching-network"
+        package=mock.Mock(), budget=10.0, driver="matching-driver", network="matching-network"
     ) as executor:
         with pytest.raises(NoPaymentAccountError) as exc_info:
-            async for _ in executor.submit(worker=mock.MagicMock(), data=mock.MagicMock()):
+            async for _ in executor.submit(worker=mock.Mock(), data=mock.Mock()):
                 pass
         exc = exc_info.value
         assert exc.required_driver == "matching-driver"
@@ -85,90 +79,71 @@ class _StopExecutor(Exception):
 
 
 @pytest.mark.asyncio
-async def test_matching_account_creates_allocation(monkeypatch):
+@mock.patch(
+    "yapapi.executor.rest.Payment.accounts",
+    _mock_accounts_iterator(
+        ("other-driver", "other-network"),
+        ("matching-driver", "matching-network", {"platform": "platform-1"}),
+        ("matching-driver", "other-network"),
+        ("other-driver", "matching-network"),
+        ("matching-driver", "matching-network", {"platform": "platform-2"}),
+    ),
+)
+@mock.patch(
+    "yapapi.executor.rest.Payment.decorate_demand",
+    mock.Mock(side_effect=_StopExecutor("decorate_demand() called")),
+)
+async def test_matching_account_creates_allocation():
     """Test that matching accounts are correctly selected and allocations are created for them."""
 
-    monkeypatch.setattr(
-        yapapi.executor.rest.Payment,
-        "accounts",
-        _mock_rest_accounts(
-            [
-                _mock_account("other-driver", "other-network"),
-                _mock_account("matching-driver", "matching-network", platform="platform-1"),
-                _mock_account("matching-driver", "other-network"),
-                _mock_account("other-driver", "matching-network"),
-                _mock_account("matching-driver", "matching-network", platform="platform-2"),
-            ]
-        ),
-    )
+    with mock.patch(
+        "ya_payment.RequestorApi.create_allocation", asynctest.CoroutineMock()
+    ) as mock_create_allocation:
+        with pytest.raises(_StopExecutor):
+            async with Executor(
+                package=mock.Mock(),
+                budget=10.0,
+                driver="matching-driver",
+                network="matching-network",
+            ) as executor:
+                async for _ in executor.submit(worker=mock.Mock(), data=mock.Mock()):
+                    pass
 
-    create_allocation_args = []
-
-    async def _mock_create_allocation(_self, model):
-        create_allocation_args.append(model)
-        return mock.MagicMock()
-
-    async def _mock_decorate_demand(*args):
-        # We're fine, no need to test further
-        raise _StopExecutor("decorate_demand called")
-
-    monkeypatch.setattr(ya_payment.RequestorApi, "create_allocation", _mock_create_allocation)
-    monkeypatch.setattr(yapapi.executor.rest.Payment, "decorate_demand", _mock_decorate_demand)
-
-    with pytest.raises(_StopExecutor):
-        async with Executor(
-            package=mock.MagicMock(),
-            budget=10.0,
-            driver="matching-driver",
-            network="matching-network",
-        ) as executor:
-            async for _ in executor.submit(worker=mock.MagicMock(), data=mock.MagicMock()):
-                pass
-
-    assert len(create_allocation_args) == 2
-    assert create_allocation_args[0].payment_platform == "platform-1"
-    assert create_allocation_args[1].payment_platform == "platform-2"
+    assert len(mock_create_allocation.call_args_list) == 2
+    assert mock_create_allocation.call_args_list[0].args[0].payment_platform == "platform-1"
+    assert mock_create_allocation.call_args_list[1].args[0].payment_platform == "platform-2"
 
 
 @pytest.mark.asyncio
-async def test_driver_network_case_insensitive(monkeypatch):
+@mock.patch("yapapi.executor.rest.Payment.accounts", _mock_accounts_iterator(("dRIVER", "NetWORK")))
+@mock.patch(
+    "ya_payment.RequestorApi.create_allocation",
+    mock.Mock(side_effect=_StopExecutor("create_allocation() called")),
+)
+async def test_driver_network_case_insensitive():
     """Test that matching driver and network names is not case sensitive."""
 
-    monkeypatch.setattr(
-        yapapi.executor.rest.Payment,
-        "accounts",
-        _mock_rest_accounts([_mock_account("dRIVER", "NetWORK")]),
-    )
-
-    async def _mock_create_allocation(*_args):
-        raise _StopExecutor("create_allocation called")
-
-    monkeypatch.setattr(ya_payment.RequestorApi, "create_allocation", _mock_create_allocation)
-
     with pytest.raises(_StopExecutor):
         async with Executor(
-            package=mock.MagicMock(), budget=10.0, driver="dRiVeR", network="NeTwOrK",
+            package=mock.Mock(), budget=10.0, driver="dRiVeR", network="NeTwOrK",
         ) as executor:
-            async for _ in executor.submit(worker=mock.MagicMock(), data=mock.MagicMock()):
+            async for _ in executor.submit(worker=mock.Mock(), data=mock.Mock()):
                 pass
 
 
 @pytest.mark.asyncio
-async def test_default_driver_network(monkeypatch):
+@mock.patch(
+    "yapapi.executor.rest.Payment.accounts",
+    _mock_accounts_iterator((DEFAULT_DRIVER, DEFAULT_NETWORK)),
+)
+@mock.patch(
+    "ya_payment.RequestorApi.create_allocation",
+    mock.Mock(side_effect=_StopExecutor("create_allocation() called")),
+)
+async def test_default_driver_network():
     """Test that defaults are used if driver and network are not specified."""
 
-    monkeypatch.setattr(
-        yapapi.executor.rest.Payment,
-        "accounts",
-        _mock_rest_accounts([_mock_account(DEFAULT_DRIVER, DEFAULT_NETWORK)]),
-    )
-
-    async def _mock_create_allocation(*_args):
-        raise _StopExecutor("create_allocation called")
-
-    monkeypatch.setattr(ya_payment.RequestorApi, "create_allocation", _mock_create_allocation)
-
     with pytest.raises(_StopExecutor):
-        async with Executor(package=mock.MagicMock(), budget=10.0) as executor:
-            async for _ in executor.submit(worker=mock.MagicMock(), data=mock.MagicMock()):
+        async with Executor(package=mock.Mock(), budget=10.0) as executor:
+            async for _ in executor.submit(worker=mock.Mock(), data=mock.Mock()):
                 pass

--- a/tests/executor/test_payment_platforms.py
+++ b/tests/executor/test_payment_platforms.py
@@ -1,0 +1,174 @@
+"""Unit tests for code that selects payment platforms based on driver/network specification."""
+import os
+from unittest import mock
+
+import pytest
+import ya_payment
+
+import yapapi
+from yapapi.executor import Executor, NoPaymentAccountError, DEFAULT_NETWORK, DEFAULT_DRIVER
+from yapapi.rest.payment import Account
+
+
+@pytest.fixture(autouse=True)
+def _set_app_key():
+    os.environ["YAGNA_APPKEY"] = "mock-appkey"
+
+
+def _mock_account(driver: str, network: str, **kwargs) -> Account:
+    """Create mock `Account` instance."""
+
+    params = {
+        "platform": "mock-platform",
+        "address": "mock-address",
+        "driver": driver,
+        "network": network,
+        "token": "mock-token",
+        "send": True,
+        "receive": True,
+    }
+    params.update(kwargs)
+    return Account(**params)
+
+
+def _mock_rest_accounts(accounts):
+    """Create mock for `Payment.accounts()`"""
+
+    async def _mock(*_args):
+        for a in accounts:
+            yield a
+
+    return _mock
+
+
+@pytest.mark.asyncio
+async def test_no_accounts_raises(monkeypatch):
+    """Test that exception is raised if `Payment.accounts()` returns empty list."""
+
+    monkeypatch.setattr(yapapi.executor.rest.Payment, "accounts", _mock_rest_accounts([]))
+
+    async with Executor(package=mock.MagicMock(), budget=10.0) as executor:
+        with pytest.raises(NoPaymentAccountError):
+            async for _ in executor.submit(worker=mock.MagicMock(), data=mock.MagicMock()):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_no_matching_account_raises(monkeypatch):
+    """Test that exception is raised if `Payment.accounts()` returns no matching accounts."""
+
+    monkeypatch.setattr(
+        yapapi.executor.rest.Payment,
+        "accounts",
+        _mock_rest_accounts(
+            [
+                _mock_account("other-driver", "other-network"),
+                _mock_account("matching-driver", "other-network"),
+                _mock_account("other-driver", "matching-network"),
+            ]
+        ),
+    )
+
+    async with Executor(
+        package=mock.MagicMock(), budget=10.0, driver="matching-driver", network="matching-network"
+    ) as executor:
+        with pytest.raises(NoPaymentAccountError) as exc_info:
+            async for _ in executor.submit(worker=mock.MagicMock(), data=mock.MagicMock()):
+                pass
+        exc = exc_info.value
+        assert exc.required_driver == "matching-driver"
+        assert exc.required_network == "matching-network"
+
+
+class _StopExecutor(Exception):
+    """An exception raised to stop the test when reaching an expected checkpoint in executor."""
+
+
+@pytest.mark.asyncio
+async def test_matching_account_creates_allocation(monkeypatch):
+    """Test that matching accounts are correctly selected and allocations are created for them."""
+
+    monkeypatch.setattr(
+        yapapi.executor.rest.Payment,
+        "accounts",
+        _mock_rest_accounts(
+            [
+                _mock_account("other-driver", "other-network"),
+                _mock_account("matching-driver", "matching-network", platform="platform-1"),
+                _mock_account("matching-driver", "other-network"),
+                _mock_account("other-driver", "matching-network"),
+                _mock_account("matching-driver", "matching-network", platform="platform-2"),
+            ]
+        ),
+    )
+
+    create_allocation_args = []
+
+    async def _mock_create_allocation(_self, model):
+        create_allocation_args.append(model)
+        return mock.MagicMock()
+
+    async def _mock_decorate_demand(*args):
+        # We're fine, no need to test further
+        raise _StopExecutor("decorate_demand called")
+
+    monkeypatch.setattr(ya_payment.RequestorApi, "create_allocation", _mock_create_allocation)
+    monkeypatch.setattr(yapapi.executor.rest.Payment, "decorate_demand", _mock_decorate_demand)
+
+    with pytest.raises(_StopExecutor):
+        async with Executor(
+            package=mock.MagicMock(),
+            budget=10.0,
+            driver="matching-driver",
+            network="matching-network",
+        ) as executor:
+            async for _ in executor.submit(worker=mock.MagicMock(), data=mock.MagicMock()):
+                pass
+
+    assert len(create_allocation_args) == 2
+    assert create_allocation_args[0].payment_platform == "platform-1"
+    assert create_allocation_args[1].payment_platform == "platform-2"
+
+
+@pytest.mark.asyncio
+async def test_driver_network_case_insensitive(monkeypatch):
+    """Test that matching driver and network names is not case sensitive."""
+
+    monkeypatch.setattr(
+        yapapi.executor.rest.Payment,
+        "accounts",
+        _mock_rest_accounts([_mock_account("dRIVER", "NetWORK")]),
+    )
+
+    async def _mock_create_allocation(*_args):
+        raise _StopExecutor("create_allocation called")
+
+    monkeypatch.setattr(ya_payment.RequestorApi, "create_allocation", _mock_create_allocation)
+
+    with pytest.raises(_StopExecutor):
+        async with Executor(
+            package=mock.MagicMock(), budget=10.0, driver="dRiVeR", network="NeTwOrK",
+        ) as executor:
+            async for _ in executor.submit(worker=mock.MagicMock(), data=mock.MagicMock()):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_default_driver_network(monkeypatch):
+    """Test that defaults are used if driver and network are not specified."""
+
+    monkeypatch.setattr(
+        yapapi.executor.rest.Payment,
+        "accounts",
+        _mock_rest_accounts([_mock_account(DEFAULT_DRIVER, DEFAULT_NETWORK)]),
+    )
+
+    async def _mock_create_allocation(*_args):
+        raise _StopExecutor("create_allocation called")
+
+    monkeypatch.setattr(ya_payment.RequestorApi, "create_allocation", _mock_create_allocation)
+
+    with pytest.raises(_StopExecutor):
+        async with Executor(package=mock.MagicMock(), budget=10.0) as executor:
+            async for _ in executor.submit(worker=mock.MagicMock(), data=mock.MagicMock()):
+                pass

--- a/yapapi/__init__.py
+++ b/yapapi/__init__.py
@@ -6,7 +6,7 @@ import toml
 from pathlib import Path
 from pkg_resources import get_distribution
 
-from .executor import Executor, Task, WorkContext, CaptureContext
+from .executor import Executor, NoPaymentAccountError, Task, WorkContext, CaptureContext
 
 
 def get_version() -> str:

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -151,6 +151,14 @@ class Executor(AsyncContextManager):
         # that emitting events will not block
         self._wrapped_consumer = AsyncWrapper(event_consumer)
 
+    @property
+    def driver(self):
+        return self._driver
+
+    @property
+    def network(self):
+        return self._network
+
     async def submit(
         self,
         worker: Callable[[WorkContext, AsyncIterator[Task[D, R]]], AsyncGenerator[Work, None]],

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -52,7 +52,30 @@ else:
 CFG_INVOICE_TIMEOUT: Final[timedelta] = timedelta(minutes=5)
 "Time to receive invoice from provider after tasks ended."
 
+DEFAULT_NETWORK = "rinkeby"
+DEFAULT_DRIVER = "zksync"
+
 logger = logging.getLogger(__name__)
+
+
+class NoPaymentAccountError(Exception):
+    """The error raised if no payment account for the required driver/network is available."""
+
+    required_driver: str
+    """Payment driver required for the account."""
+
+    required_network: str
+    """Network required for the account."""
+
+    def __init__(self, required_driver: str, required_network: str):
+        self.required_driver: str = required_driver
+        self.required_network: str = required_network
+
+    def __str__(self) -> str:
+        return (
+            f"No payment account available for driver `{self.required_driver}`"
+            f" and network `{self.required_network}`"
+        )
 
 
 @dataclass
@@ -83,23 +106,31 @@ class Executor(AsyncContextManager):
         budget: Union[float, Decimal],
         strategy: MarketStrategy = LeastExpensiveLinearPayuMS(),
         subnet_tag: Optional[str] = None,
+        driver: Optional[str] = None,
+        network: Optional[str] = None,
         event_consumer: Optional[Callable[[Event], None]] = None,
     ):
         """Create a new executor.
 
         :param package: a package common for all tasks; vm.repo() function may be
-                        used to return package from a repository
+            used to return package from a repository
         :param max_workers: maximum number of workers doing the computation
         :param timeout: timeout for the whole computation
         :param budget: maximum budget for payments
         :param strategy: market strategy used to select providers from the market
-                         (e.g. LeastExpensiveLinearPayuMS or DummyMS)
+            (e.g. LeastExpensiveLinearPayuMS or DummyMS)
         :param subnet_tag: use only providers in the subnet with the subnet_tag name
+        :param driver: name of the payment driver to use or `None` to use the default driver;
+            only payment platforms with the specified driver will be used
+        :param network: name of the network to use or `None` to use the default network;
+            only payment platforms with the specified network will be used
         :param event_consumer: a callable that processes events related to the
-                              computation; by default it is a function that logs all events
+            computation; by default it is a function that logs all events
         """
 
         self._subnet: Optional[str] = subnet_tag
+        self._driver = driver.lower() if driver else DEFAULT_DRIVER
+        self._network = network.lower() if network else DEFAULT_NETWORK
         self._stream_output = True
         self._strategy = strategy
         self._api_config = rest.Configuration()
@@ -139,7 +170,6 @@ class Executor(AsyncContextManager):
         try:
             async for result in self._submit(worker, data, services, workers):
                 yield result
-
         finally:
             # Cancel and gather all tasks to make sure all exceptions are retrieved.
             all_tasks = workers.union(services)
@@ -157,7 +187,6 @@ class Executor(AsyncContextManager):
         workers: Set[asyncio.Task],
     ) -> AsyncIterator[Task[D, R]]:
         import contextlib
-        import random
 
         stack = self._stack
         emit = cast(Callable[[Event], None], self._wrapped_consumer.async_call)
@@ -553,8 +582,23 @@ class Executor(AsyncContextManager):
                     logger.warning("Unpaid agreements  %s", agreements_to_pay)
 
     async def _create_allocations(self) -> rest.payment.MarketDecoration:
+
         if not self._budget_allocations:
             async for account in self._payment_api.accounts():
+                driver = account.driver.lower()
+                network = account.network.lower()
+                if (driver, network) != (self._driver, self._network):
+                    logger.debug(
+                        f"Not using payment platform `%s`, platform's driver/network "
+                        f"`%s`/`%s` is different than requested driver/network `%s`/`%s`",
+                        account.platform,
+                        driver,
+                        network,
+                        self._driver,
+                        self._network,
+                    )
+                    continue
+                logger.debug("Creating allocation using payment platform `%s`", account.platform)
                 allocation = cast(
                     rest.payment.Allocation,
                     await self._stack.enter_async_context(
@@ -567,9 +611,10 @@ class Executor(AsyncContextManager):
                     ),
                 )
                 self._budget_allocations.append(allocation)
-        assert (
-            self._budget_allocations
-        ), "No payment accounts. Did you forget to run 'yagna payment init -r'?"
+
+            if not self._budget_allocations:
+                raise NoPaymentAccountError(self._driver, self._network)
+
         allocation_ids = [allocation.id for allocation in self._budget_allocations]
         return await self._payment_api.decorate_demand(allocation_ids)
 


### PR DESCRIPTION
Resolves #211 

* New parameters `driver` and `network` are added to `Executor()`. Default values are `zksync` and `rinkeby`.
* When creating the allocations in the executor, the requestor accounts are now filtered by comparing their driver and network with the values specified for the executor.
* If no matching accounts are found, a new exception `NoPaymentAccountsError` is raised.
* Optional commandline params `--driver` and `--network` are added to blender.py` and `yacat.py`. 