### PR TITLE
Add __init__.py to make examples dir a package and facilitate imports

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -27,7 +27,7 @@ from examples.utils import (
 script_dir = pathlib.Path(__file__).resolve().parent
 
 
-async def main(subnet_tag: str):
+async def main(subnet_tag):
     package = await vm.repo(
         image_hash="9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
         min_mem_gib=0.5,

--- a/examples/low-level-api/list-offers.py
+++ b/examples/low-level-api/list-offers.py
@@ -3,11 +3,14 @@ import asyncio
 from asyncio import TimeoutError
 from datetime import datetime, timezone
 import json
+import sys
 
 from yapapi import props as yp
 from yapapi.log import enable_default_logger
 from yapapi.props.builder import DemandBuilder
 from yapapi.rest import Configuration, Market, Activity, Payment  # noqa
+
+from examples import utils
 
 
 async def list_offers(conf: Configuration, subnet_tag: str):
@@ -27,14 +30,6 @@ async def list_offers(conf: Configuration, subnet_tag: str):
 
 
 def main():
-    import pathlib
-    import sys
-
-    parent_directory = pathlib.Path(__file__).resolve().parent.parent
-    sys.stderr.write(f"Adding {parent_directory} to sys.path.\n")
-    sys.path.append(str(parent_directory))
-    import utils
-
     parser = utils.build_parser("List offers")
     args = parser.parse_args()
 


### PR DESCRIPTION
`blender.py` and `yacat.py` use some stuff from `examples/utils.py`.
We currently tinker with `sys.path` to import `examples/utils.py`:
```
# For importing `utils.py`:
script_dir = pathlib.Path(__file__).resolve().parent
parent_directory = script_dir.parent
sys.stderr.write(f"Adding {parent_directory} to sys.path.\n")
sys.path.append(str(parent_directory))
import utils  # noqa
```
This works but is ugly and causes issues with IDEs.

A simple solution is to add `__init__.py` files to `examples` thus making it a package. `utils.py` can then be imported as follows:
```
import examples.utils
```