### PR TITLE
Tinker with sys.path to import examples.utils (again!)

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -16,6 +16,9 @@ from yapapi.log import enable_default_logger, log_summary, log_event_repr  # noq
 from yapapi.package import vm
 from yapapi.rest.activity import BatchTimeoutError
 
+root_dir = pathlib.Path(__file__).resolve().parent.parent.parent
+sys.path.append(str(root_dir))
+
 from examples.utils import (
     build_parser,
     TEXT_COLOR_CYAN,

--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -16,10 +16,10 @@ from yapapi.log import enable_default_logger, log_summary, log_event_repr  # noq
 from yapapi.package import vm
 from yapapi.rest.activity import BatchTimeoutError
 
-root_dir = pathlib.Path(__file__).resolve().parent.parent.parent
-sys.path.append(str(root_dir))
+examples_dir = pathlib.Path(__file__).resolve().parent.parent
+sys.path.append(str(examples_dir))
 
-from examples.utils import (
+from utils import (
     build_parser,
     TEXT_COLOR_CYAN,
     TEXT_COLOR_DEFAULT,

--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -8,10 +8,10 @@ from yapapi import Executor, NoPaymentAccountError, Task, WorkContext, windows_e
 from yapapi.log import enable_default_logger, log_summary, log_event_repr  # noqa
 from yapapi.package import vm
 
-root_dir = pathlib.Path(__file__).resolve().parent.parent.parent
-sys.path.append(str(root_dir))
+examples_dir = pathlib.Path(__file__).resolve().parent.parent
+sys.path.append(str(examples_dir))
 
-from examples.utils import (
+from utils import (
     build_parser,
     TEXT_COLOR_CYAN,
     TEXT_COLOR_DEFAULT,

--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -8,6 +8,9 @@ from yapapi import Executor, NoPaymentAccountError, Task, WorkContext, windows_e
 from yapapi.log import enable_default_logger, log_summary, log_event_repr  # noqa
 from yapapi.package import vm
 
+root_dir = pathlib.Path(__file__).resolve().parent.parent.parent
+sys.path.append(str(root_dir))
+
 from examples.utils import (
     build_parser,
     TEXT_COLOR_CYAN,


### PR DESCRIPTION
This PR partially reverts https://github.com/golemfactory/yapapi/pull/220. It turned out adding `__init__.py` to `examples` directory makes `import examples.utils` work only in the environment activated by `poetry shell` (because `poetry shell` adds the root project dir to `sys.path`).

In other scenarios (in particular, when following the official tutorial) one still needs to manually extend `sys.path` in order to be able to do `import utils` or `import examples.utils`.