### PR TITLE
Include provider ids in keys in SummaryLogger maps

### DIFF
--- a/yapapi/executor/agreements_pool.py
+++ b/yapapi/executor/agreements_pool.py
@@ -122,7 +122,11 @@ class AgreementsPool:
         requestor_activity = agreement_details.requestor_view.extract(Activity)
         node_info = agreement_details.provider_view.extract(NodeInfo)
         logger.debug("New agreement. id: %s, provider: %s", agreement.id, node_info)
-        emit(events.AgreementCreated(agr_id=agreement.id, provider_id=node_info))
+        emit(
+            events.AgreementCreated(
+                agr_id=agreement.id, provider_id=provider_id, provider_info=node_info
+            )
+        )
         if not await agreement.confirm():
             emit(events.AgreementRejected(agr_id=agreement.id))
             return None

--- a/yapapi/executor/events.py
+++ b/yapapi/executor/events.py
@@ -109,7 +109,8 @@ class AgreementEvent(Event):
 
 @dataclass
 class AgreementCreated(AgreementEvent):
-    provider_id: NodeInfo
+    provider_id: str
+    provider_info: NodeInfo
 
 
 @dataclass

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -112,20 +112,20 @@ event_type_to_string = {
     events.CollectFailed: "Failed to collect proposals for demand",
     events.NoProposalsConfirmed: "No proposals confirmed by providers",
     events.ProposalReceived: "Proposal received from the market",
-    events.ProposalRejected: "Proposal rejected",  # by who? alt: Rejected a proposal?
+    events.ProposalRejected: "Proposal rejected",
     events.ProposalResponded: "Responded to a proposal",
     events.ProposalFailed: "Failed to respond to proposal",
-    events.ProposalConfirmed: "Proposal confirmed by provider",  # ... negotiated with provider?
+    events.ProposalConfirmed: "Proposal confirmed by provider",
     events.AgreementCreated: "Agreement proposal sent to provider",
     events.AgreementConfirmed: "Agreement approved by provider",
     events.AgreementRejected: "Agreement rejected by provider",
     events.AgreementTerminated: "Agreement terminated",
     events.DebitNoteReceived: "Debit note received",
-    events.PaymentAccepted: "Payment accepted",  # by who?
+    events.PaymentAccepted: "Payment accepted",
     events.PaymentFailed: "Payment failed",
     events.PaymentPrepared: "Payment prepared",
     events.PaymentQueued: "Payment queued",
-    events.InvoiceReceived: "Invoice received",  # by who?
+    events.InvoiceReceived: "Invoice received",
     events.WorkerStarted: "Worker started for agreement",
     events.ActivityCreated: "Activity created on provider",
     events.ActivityCreateFailed: "Failed to create activity",
@@ -137,8 +137,8 @@ event_type_to_string = {
     events.CommandExecuted: "Script command executed",
     events.GettingResults: "Getting script results",
     events.ScriptFinished: "Script finished",
-    events.TaskAccepted: "Task accepted",  # by who?
-    events.TaskRejected: "Task rejected",  # by who?
+    events.TaskAccepted: "Task accepted",
+    events.TaskRejected: "Task rejected",
     events.WorkerFinished: "Worker finished",
     events.DownloadStarted: "Download started",
     events.DownloadFinished: "Download finished",
@@ -310,8 +310,8 @@ class SummaryLogger:
             len(self.confirmed_agreements),
             num_providers,
         )
-        for provider_name, tasks in self.provider_tasks.items():
-            self.logger.info("Provider '%s' computed %d tasks", provider_name, len(tasks))
+        for info, tasks in self.provider_tasks.items():
+            self.logger.info("Provider '%s' computed %d tasks", info.provider_name, len(tasks))
         for info in set(self.agreement_provider_info.values()):
             if info not in self.provider_tasks:
                 self.logger.info("Provider '%s' did not compute any tasks", info.provider_name)

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -200,9 +200,9 @@ def log_event_repr(event: events.Event) -> None:
 
 @dataclass(frozen=True)
 class ProviderInfo:
-    provider_id: str
-    provider_name: str
-    provider_subnet: Optional[str]
+    id: str
+    name: str
+    subnet_tag: Optional[str]
 
 
 class SummaryLogger:
@@ -311,12 +311,12 @@ class SummaryLogger:
             num_providers,
         )
         for info, tasks in self.provider_tasks.items():
-            self.logger.info("Provider '%s' computed %d tasks", info.provider_name, len(tasks))
+            self.logger.info("Provider '%s' computed %d tasks", info.name, len(tasks))
         for info in set(self.agreement_provider_info.values()):
             if info not in self.provider_tasks:
-                self.logger.info("Provider '%s' did not compute any tasks", info.provider_name)
+                self.logger.info("Provider '%s' did not compute any tasks", info.name)
         for info, num in self.provider_failures.items():
-            self.logger.info("Activity failed %d time(s) on provider '%s'", num, info.provider_name)
+            self.logger.info("Activity failed %d time(s) on provider '%s'", num, info.name)
 
     def _print_total_cost(self, partial: bool = False) -> None:
         """Print the sum of all accepted invoices."""
@@ -397,7 +397,7 @@ class SummaryLogger:
         elif isinstance(event, events.AgreementConfirmed):
             self.logger.info(
                 "Agreement confirmed by provider '%s'",
-                self.agreement_provider_info[event.agr_id].provider_name,
+                self.agreement_provider_info[event.agr_id].name,
             )
             self.confirmed_agreements.add(event.agr_id)
 
@@ -408,7 +408,7 @@ class SummaryLogger:
             provider_info = self.agreement_provider_info[event.agr_id]
             self.logger.info(
                 "Task sent to provider '%s', task data: %s",
-                provider_info.provider_name,
+                provider_info.name,
                 self.task_data[event.task_id] if event.task_id else "<initialization>",
             )
 
@@ -416,7 +416,7 @@ class SummaryLogger:
             provider_info = self.agreement_provider_info[event.agr_id]
             self.logger.info(
                 "Task computed by provider '%s', task data: %s",
-                provider_info.provider_name,
+                provider_info.name,
                 self.task_data[event.task_id] if event.task_id else "<initialization>",
             )
             if event.task_id:
@@ -443,7 +443,7 @@ class SummaryLogger:
             self.provider_failures[provider_info] += 1
             reason = str(exc) or repr(exc) or "unexpected error"
             self.logger.warning(
-                "Activity failed on provider '%s', reason: %s", provider_info.provider_name, reason
+                "Activity failed on provider '%s', reason: %s", provider_info.name, reason
             )
 
         elif isinstance(event, events.ComputationFinished):

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -249,9 +249,6 @@ class SummaryLogger:
     # Maps task id to task data
     task_data: Dict[str, Any]
 
-    # Maps provider ids to names
-    # provider_name: Dict[str, str]
-
     # Maps a provider info to the list of task ids computed by the provider
     provider_tasks: Dict[ProviderInfo, List[str]]
 
@@ -293,7 +290,6 @@ class SummaryLogger:
         self.agreement_provider_info = {}
         self.confirmed_agreements = set()
         self.task_data = {}
-        # self.provider_name = {}
         self.provider_tasks = defaultdict(list)
         self.provider_failures = Counter()
         self.cancelled = False


### PR DESCRIPTION
Resolves #146 

Some dictionaries in `SummaryLogger` are currently using provider names, which may not be unique, as keys.

This PR changes those dictionaries to use structured keys (dataclasses) that contain a provider name, a subnet (for possible future use) and a provider id (address).