### PR TITLE
Set encoding to "utf-8" for the debug log file in log.py

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,8 +1,12 @@
 """Unit tests for the `yapapi.log` module."""
 import logging
+import sys
 import tempfile
 
-from yapapi.log import enable_default_logger
+import pytest
+
+from yapapi.executor.events import ComputationFinished
+from yapapi.log import enable_default_logger, log_event, log_event_repr
 
 
 def test_log_file_encoding(capsys):
@@ -19,3 +23,22 @@ def test_log_file_encoding(capsys):
 
     err = capsys.readouterr().err
     assert "UnicodeEncodeError" not in err
+
+
+@pytest.mark.skip("See https://github.com/golemfactory/yapapi/issues/227")
+def test_log_event_emit_traceback():
+    """Test that `log.log_event()` can emit logs for events containing tracebacks arguments."""
+
+    try:
+        raise Exception("Hello!")
+    except:
+        log_event(ComputationFinished(exc_info=sys.exc_info()))
+
+
+def test_log_event_repr_emit_traceback():
+    """Test that `log.log_event_repr()` can emit logs for events containing traceback arguments."""
+
+    try:
+        raise Exception("Hello!")
+    except:
+        log_event_repr(ComputationFinished(exc_info=sys.exc_info()))

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,21 @@
+"""Unit tests for the `yapapi.log` module."""
+import logging
+import tempfile
+
+from yapapi.log import enable_default_logger
+
+
+def test_log_file_encoding(capsys):
+    """Test that logging some fancy Unicode to file does not cause encoding errors.
+
+    `capsys` is a `pytest` fixture for capturing and accessing stdout/stderr, see
+    https://docs.pytest.org/en/stable/capture.html#accessing-captured-output-from-a-test-function.
+    """
+
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        enable_default_logger(log_file=tmpfile.name)
+        logger = logging.getLogger("yapapi")
+        logger.debug("| (• ◡•)| It's Adventure Time! (❍ᴥ❍ʋ)")
+
+    err = capsys.readouterr().err
+    assert "UnicodeEncodeError" not in err

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -148,9 +148,9 @@ class Executor(AsyncContextManager):
         if not event_consumer:
             # Use local import to avoid cyclic imports when yapapi.log
             # is imported by client code
-            from ..log import log_event
+            from ..log import log_event_repr
 
-            event_consumer = log_event
+            event_consumer = log_event_repr
         # Add buffering to the provided event emitter to make sure
         # that emitting events will not block
         self._wrapped_consumer = AsyncWrapper(event_consumer)

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -83,7 +83,7 @@ def enable_default_logger(
     logger.addHandler(console_handler)
 
     if log_file:
-        file_handler = logging.FileHandler(filename=log_file, mode="w")
+        file_handler = logging.FileHandler(filename=log_file, mode="w", encoding="utf-8")
         file_handler.setFormatter(formatter)
         file_handler.setLevel(logging.DEBUG)
         logger.addHandler(file_handler)


### PR DESCRIPTION
Resolves #166 

When working on unit tests for this PR, a bug in function `log.log_event()` has been found, see #227.