### PR TITLE
remove the gitignore files for examples

### DIFF
--- a/examples/blender/.gitignore
+++ b/examples/blender/.gitignore
@@ -1,1 +1,0 @@
-output_*.png

--- a/examples/yacat/.gitignore
+++ b/examples/yacat/.gitignore
@@ -1,3 +1,0 @@
-hashcat_*.potfile
-in.hash
-keyspace.*


### PR DESCRIPTION
actually, I do believe it's better if those files are _not_ ignored...
for anyone whom it bothers, you can always create your own local ignores and imvho it makes verifying whether the examples worked correctly more cumbersome ... for me, seeing that at one glance is a feature not an issue