### PR TITLE
Update 'no payment account' message to refer to the handbook

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -12,7 +12,7 @@ from yapapi import (
     WorkContext,
     windows_event_loop_fix,
 )
-from yapapi.log import enable_default_logger, log_summary, log_event_repr  # noqa
+from yapapi.log import enable_default_logger, log_summary, log_event  # noqa
 from yapapi.package import vm
 from yapapi.rest.activity import BatchTimeoutError
 
@@ -100,7 +100,7 @@ async def main(subnet_tag, driver=None, network=None):
         subnet_tag=subnet_tag,
         driver=driver,
         network=network,
-        event_consumer=log_summary(log_event_repr),
+        event_consumer=log_summary(log_event),
     ) as executor:
 
         sys.stderr.write(
@@ -141,10 +141,15 @@ if __name__ == "__main__":
     try:
         loop.run_until_complete(task)
     except NoPaymentAccountError as e:
+        handbook_url = (
+            "https://handbook.golem.network/requestor-tutorials/"
+            "flash-tutorial-of-requestor-development"
+        )
         print(
             f"{TEXT_COLOR_RED}"
             f"No payment account initialized for driver `{e.required_driver}` "
-            f"and network `{e.required_network}`. Did you run `yagna payment init -r`?"
+            f"and network `{e.required_network}`.\n\n"
+            f"See {handbook_url} on how to initialize payment accounts for a requestor node."
             f"{TEXT_COLOR_DEFAULT}"
         )
     except KeyboardInterrupt:

--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -168,10 +168,15 @@ if __name__ == "__main__":
     try:
         loop.run_until_complete(task)
     except NoPaymentAccountError as e:
+        handbook_url = (
+            "https://handbook.golem.network/requestor-tutorials/"
+            "flash-tutorial-of-requestor-development"
+        )
         print(
             f"{TEXT_COLOR_RED}"
             f"No payment account initialized for driver `{e.required_driver}` "
-            f"and network `{e.required_network}`. Did you run `yagna payment init -r`?"
+            f"and network `{e.required_network}`.\n\n"
+            f"See {handbook_url} on how to initialize payment accounts for a requestor node."
             f"{TEXT_COLOR_DEFAULT}"
         )
     except KeyboardInterrupt:


### PR DESCRIPTION
Resolves #225 

Before:
```
No payment account initialized for driver `zzz` and network `rinkeby`. Did you run `yagna payment init -r`?
```
After:
```
No payment account initialized for driver `zzz` and network `rinkeby`.

See https://handbook.golem.network/requestor-tutorials/flash-tutorial-of-requestor-development#enable-the-daemon-as-a-requestor on how to initialize payment accounts for a requestor node.
```

EDIT: I've shortened the URL to point to the tutorial page, not a section therein, so it's less prone to becoming outdated.
```
No payment account initialized for driver `zzz` and network `rinkeby`.

See https://handbook.golem.network/requestor-tutorials/flash-tutorial-of-requestor-development on how to initialize payment accounts for a requestor node.
```