### PR TITLE
Fix yapapi.log.log_event()

### DIFF
--- a/tests/executor/test_payment_platforms.py
+++ b/tests/executor/test_payment_platforms.py
@@ -1,5 +1,4 @@
 """Unit tests for code that selects payment platforms based on driver/network specification."""
-import os
 from unittest import mock
 
 import pytest

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -37,7 +37,6 @@ def test_log_file_encoding(capsys):
         os.unlink(tmp_file.name)
 
 
-@pytest.mark.skip("See https://github.com/golemfactory/yapapi/issues/227")
 def test_log_event_emit_traceback():
     """Test that `log.log_event()` can emit logs for events containing tracebacks arguments."""
 

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -170,30 +170,22 @@ _check_event_type_to_string()
 
 
 def log_event(event: events.Event) -> None:
-    """Log an event in human-readable representation."""
+    """Log `event` with a human-readable description."""
 
     loglevel = logging.DEBUG
-
-    def _format(obj: Any, max_len: int = 200) -> str:
-        # This will also escape control characters, in particular,
-        # newline characters in `obj` will be replaced by r"\n".
-        text = repr(obj)
-        if len(text) > max_len:
-            text = text[: max_len - 3] + "..."
-        return text
 
     if not event_logger.isEnabledFor(loglevel):
         return
 
-    msg = event_type_to_string[type(event)]
-    info = "; ".join(f"{name} = {_format(value)}" for name, value in asdict(event).items())
-    if info:
-        msg += "; " + info
-    event_logger.log(loglevel, msg)
+    exc_info, _ = event.extract_exc_info()
+    descr = event_type_to_string[type(event)]
+    msg = "; ".join([descr, *(f"{name} = {value}" for name, value in event.__dict__.items())])
+    event_logger.log(loglevel, msg, exc_info=exc_info)
 
 
 def log_event_repr(event: events.Event) -> None:
-    """Log the result of calling `__repr__()` for the `event`."""
+    """Log the result of calling `repr(event)`."""
+
     exc_info, _ = event.extract_exc_info()
     event_logger.debug("%r", event, exc_info=exc_info)
 


### PR DESCRIPTION
The function crashes for some events, see #227. 

This PR fixes this (but does not remove or deprecate `log_event()`, as #227 suggests).