### PR TITLE
Log yapapi version and Executor() arguments to file

### DIFF
--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -131,6 +131,7 @@ class Executor(AsyncContextManager):
         :param event_consumer: a callable that processes events related to the
             computation; by default it is a function that logs all events
         """
+        logger.debug("Creating Executor instance; parameters: %s", locals())
 
         self._subnet: Optional[str] = subnet_tag
         self._driver = driver.lower() if driver else DEFAULT_DRIVER
@@ -151,6 +152,7 @@ class Executor(AsyncContextManager):
             from ..log import log_event_repr
 
             event_consumer = log_event_repr
+
         # Add buffering to the provided event emitter to make sure
         # that emitting events will not block
         self._wrapped_consumer = AsyncWrapper(event_consumer)

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -43,15 +43,17 @@ as an argument to `log_summary`:
 """
 from asyncio import CancelledError
 from collections import defaultdict, Counter
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import itertools
 import logging
+import os
+import sys
 import time
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set
 
 import yapapi.executor.events as events
-
+from yapapi import __version__ as yapapi_version
 
 event_logger = logging.getLogger("yapapi.events")
 executor_logger = logging.getLogger("yapapi.executor")
@@ -88,7 +90,13 @@ def enable_default_logger(
         file_handler.setLevel(logging.DEBUG)
         logger.addHandler(file_handler)
 
-        executor_logger.info(
+        logger.debug(
+            "Yapapi version: %s, script: %s, working directory: %s",
+            yapapi_version,
+            sys.argv[0],
+            os.getcwd(),
+        )
+        logger.info(
             "Using log file `%s`; in case of errors look for additional information there", log_file
         )
 


### PR DESCRIPTION
The first and the third line in the debug log are added by this PR:  
```
[2021-02-03 09:47:19,114 DEBUG yapapi] Yapapi version: 0.5.0-alpha.2, script: examples/blender/blender.py, working directory: /home/azawlocki/golem/yapapi
[2021-02-03 09:47:19,114 INFO yapapi] Using log file `blender-yapapi.log`; in case of errors look for additional information there
[2021-02-03 09:47:19,305 DEBUG yapapi.executor] Creating Executor instance; parameters: {'self': <yapapi.executor.Executor object at 0x7f87b58ad3d0>, 'package': _VmPackage(repo_url='http://yacn.dev.golem.network:8000', image_hash='9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae', constraints=_VmConstrains(min_mem_gib=0.5, min_storage_gib=2.0, cores=1)), 'max_workers': 3, 'timeout': datetime.timedelta(seconds=900), 'budget': 10.0, 'strategy': LeastExpensiveLinearPayuMS(), 'subnet_tag': 'devnet-alpha.4', 'driver': None, 'network': None, 'event_consumer': <bound method SummaryLogger.log of <yapapi.log.SummaryLogger object at 0x7f87b58aded0>>}
```