### PR TITLE
Don't print total time on executor shutdown; do print it in examples

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta
 import pathlib
 import sys
 
@@ -12,7 +12,7 @@ from yapapi import (
     WorkContext,
     windows_event_loop_fix,
 )
-from yapapi.log import enable_default_logger, log_summary, log_event  # noqa
+from yapapi.log import enable_default_logger, log_summary, log_event_repr  # noqa
 from yapapi.package import vm
 from yapapi.rest.activity import BatchTimeoutError
 
@@ -100,7 +100,7 @@ async def main(subnet_tag, driver=None, network=None):
         subnet_tag=subnet_tag,
         driver=driver,
         network=network,
-        event_consumer=log_summary(log_event),
+        event_consumer=log_summary(log_event_repr),
     ) as executor:
 
         sys.stderr.write(
@@ -110,12 +110,22 @@ async def main(subnet_tag, driver=None, network=None):
             f"and network: {TEXT_COLOR_YELLOW}{executor.network}{TEXT_COLOR_DEFAULT}\n"
         )
 
+        num_tasks = 0
+        start_time = datetime.now()
+
         async for task in executor.submit(worker, [Task(data=frame) for frame in frames]):
+            num_tasks += 1
             print(
                 f"{TEXT_COLOR_CYAN}"
                 f"Task computed: {task}, result: {task.result}, time: {task.running_time}"
                 f"{TEXT_COLOR_DEFAULT}"
             )
+
+        print(
+            f"{TEXT_COLOR_CYAN}"
+            f"{num_tasks} tasks computed, total time: {datetime.now() - start_time}"
+            f"{TEXT_COLOR_DEFAULT}"
+        )
 
 
 if __name__ == "__main__":

--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta
 import pathlib
 import sys
 
@@ -113,6 +113,8 @@ async def main(args):
         )
 
         keyspace_computed = False
+        start_time = datetime.now()
+
         # This is not a typical use of executor.submit as there is only one task, with no data:
         async for _task in executor.submit(worker_check_keyspace, [Task(data=None)]):
             keyspace_computed = True
@@ -146,6 +148,8 @@ async def main(args):
             print(f"{TEXT_COLOR_RED}No password found{TEXT_COLOR_DEFAULT}")
         else:
             print(f"{TEXT_COLOR_GREEN}Password found: {password}{TEXT_COLOR_DEFAULT}")
+
+        print(f"{TEXT_COLOR_CYAN}Total time: {datetime.now() - start_time}{TEXT_COLOR_DEFAULT}")
 
 
 if __name__ == "__main__":

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -461,8 +461,7 @@ class SummaryLogger:
             self._print_total_cost()
             self.provider_cost = {}
             if not event.exc_info:
-                total_time = time.time() - self.start_time
-                self.logger.info(f"Executor shut down, total time: {total_time:.1f}s")
+                self.logger.info(f"Executor has shut down")
             else:
                 _exc_type, exc, _tb = event.exc_info
                 reason = str(exc) or repr(exc) or "unexpected error"


### PR DESCRIPTION
Resolves #237 

Currently, a message like this is logged when an `Executor` is shut down:
```
[2021-02-04 12:56:08,209 INFO yapapi.summary] Executor shut down, total time: 23.5s
``` 
The `total time` is a wall time elapsed from the moment the last computation was started in `Executor.submit()` up to the moment the executor is shut down in `Executor.__aexit__()` (more precisely, the time between the last `ComputationStarted` and `ShutdownFinished` executor events).

In a simple scenario in which a requestor consists essentially of a single `Executor.submit()` call (as in `blender.py`), the `total time` is close to a total running time of the requestor, which may be a useful information. In more complex scenarios, when `submit()` is called more than once on a single `Executor` instance (in sequence, as in `yacat.py`, or concurrently, as in some example we don't have yet) this time is less useful and may be misleading (as seen in #237).

Therefore, this PR replaces the `total time` printed in the summary logger with executor shutdown time (the time required for an `Executor` instance to close all `asyncio` tasks, including waiting for invoices). Recording & reporting the total computation time is delegated to the example requestor scripts.

For example, the line with `total time` is printed in `blender.py` (the rest comes from `yapapi`'s summary logger): 
```
[2021-02-08 14:52:30,328 INFO yapapi.summary] Task computed by provider 'mbenke.4', task data: 50
Task computed: Task(id=6, data=50), result: output_50.png, time: 0:00:04.517777
[2021-02-08 14:52:30,334 INFO yapapi.summary] Computation finished in 26.5s
[2021-02-08 14:52:30,334 INFO yapapi.summary] Negotiated 3 agreements with 3 providers
[2021-02-08 14:52:30,335 INFO yapapi.summary] Provider '2rec-ubuntu.4' computed 3 tasks
[2021-02-08 14:52:30,335 INFO yapapi.summary] Provider 'mbenke.4' computed 3 tasks
[2021-02-08 14:52:30,335 INFO yapapi.summary] Provider 'qbam.4' did not compute any tasks
6 tasks computed, total time: 0:00:38.414154
[2021-02-08 14:52:41,619 INFO yapapi.summary] Total cost: 0.138767596637
[2021-02-08 14:52:41,619 INFO yapapi.summary] Executor shut down in 11.3s
```
```