### PR TITLE
Fix deadlock in AsyncWrapper's stop() coroutine

### DIFF
--- a/examples/utils.py
+++ b/examples/utils.py
@@ -19,7 +19,7 @@ def build_parser(description: str):
     parser.add_argument("--driver", help="Payment driver name, for example `zksync`")
     parser.add_argument("--network", help="Network name, for example `rinkeby`")
     parser.add_argument(
-        "--subnet-tag", default="devnet-alpha.4", help="Subnet name; default: %(default)s"
+        "--subnet-tag", default="community.4", help="Subnet name; default: %(default)s"
     )
     parser.add_argument(
         "--log-file", default=None, help="Log file for YAPAPI; default: %(default)s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.5.0-alpha.4"
+version = "0.5.0-alpha.5"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>", "GolemFactory <contact@golem.network>"]
 license = "LGPL-3.0-or-later"

--- a/tests/executor/test_async_wrapper.py
+++ b/tests/executor/test_async_wrapper.py
@@ -1,11 +1,15 @@
 import asyncio
 import pytest
+import time
 
 from yapapi.executor.utils import AsyncWrapper
 
 
 def test_keyboard_interrupt():
     """Test if AsyncWrapper handles KeyboardInterrupt by passing it to the event loop."""
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     def func(interrupt):
         if interrupt:
@@ -20,7 +24,6 @@ def test_keyboard_interrupt():
             wrapper.async_call(True)
             await asyncio.sleep(0.01)
 
-    loop = asyncio.get_event_loop()
     task = loop.create_task(main())
     with pytest.raises(KeyboardInterrupt):
         loop.run_until_complete(task)
@@ -30,3 +33,84 @@ def test_keyboard_interrupt():
 
     # Make sure the wrapper can still make calls, it's worker task shouldn't exit
     wrapper.async_call(False)
+
+    loop.close()
+
+
+def test_stop_doesnt_deadlock():
+    """Test if the AsyncWrapper.stop() coroutine completes after an AsyncWrapper is interrupted.
+
+    See https://github.com/golemfactory/yapapi/issues/238.
+    """
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    def func(n):
+        print(f"func({n}) called")
+        if n == 10:
+            time.sleep(1.0)
+            print("interrupt!")
+            raise KeyboardInterrupt()
+
+    async def main():
+        """"This coroutine mimics how an AsyncWrapper is used in an Executor."""
+
+        wrapper = AsyncWrapper(func)
+        # Queue some calls
+        for n in range(20):
+            wrapper.async_call(n)
+        try:
+            # Sleep until cancelled
+            await asyncio.sleep(100)
+        except (KeyboardInterrupt, asyncio.CancelledError, Exception):
+            await wrapper.stop()
+
+    task = loop.create_task(main())
+    try:
+        loop.run_until_complete(task)
+        assert False, "Expected KeyboardInterrupt"
+    except KeyboardInterrupt:
+        task.cancel()
+        try:
+            loop.run_until_complete(task)
+        except KeyboardInterrupt:
+            pass
+
+    loop.close()
+
+
+def test_stop_doesnt_wait():
+    """Test if the AsyncWrapper.stop() coroutine completes after an AsyncWrapper is interrupted."""
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    def func():
+        pass
+
+    wrapper = AsyncWrapper(func)
+
+    async def main():
+        with pytest.raises(RuntimeError):
+            for n in range(1000):
+                await asyncio.sleep(0.1)
+                wrapper.async_call()
+            assert False, "Should raise RuntimeError"
+
+    async def stop():
+        await asyncio.sleep(1.0)
+        await wrapper.stop()
+
+    task = loop.create_task(main())
+    loop.create_task(stop())
+    try:
+        loop.run_until_complete(task)
+    except KeyboardInterrupt:
+        task.cancel()
+        try:
+            loop.run_until_complete(task)
+        except KeyboardInterrupt:
+            pass
+
+    loop.close()

--- a/tests/executor/test_async_wrapper.py
+++ b/tests/executor/test_async_wrapper.py
@@ -5,17 +5,14 @@ import time
 from yapapi.executor.utils import AsyncWrapper
 
 
-def test_keyboard_interrupt():
+def test_keyboard_interrupt(event_loop):
     """Test if AsyncWrapper handles KeyboardInterrupt by passing it to the event loop."""
-
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     def func(interrupt):
         if interrupt:
             raise KeyboardInterrupt
 
-    wrapper = AsyncWrapper(func)
+    wrapper = AsyncWrapper(func, event_loop)
 
     async def main():
         for _ in range(100):
@@ -24,9 +21,9 @@ def test_keyboard_interrupt():
             wrapper.async_call(True)
             await asyncio.sleep(0.01)
 
-    task = loop.create_task(main())
+    task = event_loop.create_task(main())
     with pytest.raises(KeyboardInterrupt):
-        loop.run_until_complete(task)
+        event_loop.run_until_complete(task)
 
     # Make sure the main task did not get KeyboardInterrupt
     assert not task.done()
@@ -34,83 +31,70 @@ def test_keyboard_interrupt():
     # Make sure the wrapper can still make calls, it's worker task shouldn't exit
     wrapper.async_call(False)
 
-    loop.close()
 
-
-def test_stop_doesnt_deadlock():
+def test_stop_doesnt_deadlock(event_loop):
     """Test if the AsyncWrapper.stop() coroutine completes after an AsyncWrapper is interrupted.
 
     See https://github.com/golemfactory/yapapi/issues/238.
     """
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-
-    def func(n):
-        print(f"func({n}) called")
-        if n == 10:
+    def func(interrupt):
+        if interrupt:
             time.sleep(1.0)
-            print("interrupt!")
             raise KeyboardInterrupt()
 
     async def main():
         """"This coroutine mimics how an AsyncWrapper is used in an Executor."""
 
-        wrapper = AsyncWrapper(func)
-        # Queue some calls
-        for n in range(20):
-            wrapper.async_call(n)
+        wrapper = AsyncWrapper(func, event_loop)
         try:
+            # Queue some calls
+            for _ in range(10):
+                wrapper.async_call(False)
+            wrapper.async_call(True)
+            for _ in range(10):
+                wrapper.async_call(False)
             # Sleep until cancelled
-            await asyncio.sleep(100)
-        except (KeyboardInterrupt, asyncio.CancelledError, Exception):
-            await wrapper.stop()
+            await asyncio.sleep(30)
+            assert False, "Sleep should be cancelled"
+        except asyncio.CancelledError:
+            # This call should exit without timeout
+            await asyncio.wait_for(wrapper.stop(), timeout=30.0)
 
-    task = loop.create_task(main())
+    task = event_loop.create_task(main())
     try:
-        loop.run_until_complete(task)
+        event_loop.run_until_complete(task)
         assert False, "Expected KeyboardInterrupt"
     except KeyboardInterrupt:
         task.cancel()
-        try:
-            loop.run_until_complete(task)
-        except KeyboardInterrupt:
-            pass
-
-    loop.close()
+        event_loop.run_until_complete(task)
 
 
-def test_stop_doesnt_wait():
-    """Test if the AsyncWrapper.stop() coroutine completes after an AsyncWrapper is interrupted."""
-
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+def test_stop_doesnt_wait(event_loop):
+    """Test if the AsyncWrapper.stop() coroutine prevents new calls from be queued."""
 
     def func():
+        time.sleep(0.1)
         pass
 
-    wrapper = AsyncWrapper(func)
+    wrapper = AsyncWrapper(func, event_loop)
 
     async def main():
         with pytest.raises(RuntimeError):
-            for n in range(1000):
-                await asyncio.sleep(0.1)
+            for n in range(100):
                 wrapper.async_call()
+                await asyncio.sleep(0.01)
+            # wrapper should be stopped before all calls are made
             assert False, "Should raise RuntimeError"
 
     async def stop():
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(0.1)
         await wrapper.stop()
 
-    task = loop.create_task(main())
-    loop.create_task(stop())
+    task = event_loop.create_task(main())
+    event_loop.create_task(stop())
     try:
-        loop.run_until_complete(task)
+        event_loop.run_until_complete(task)
     except KeyboardInterrupt:
         task.cancel()
-        try:
-            loop.run_until_complete(task)
-        except KeyboardInterrupt:
-            pass
-
-    loop.close()
+        event_loop.run_until_complete(task)


### PR DESCRIPTION
Resolves #238 

Most probably, the cause of #238 is the following scenario:

1. The requestor is interrupted by ctrl+c that causes `KeyboardInterrupt` to be raised in `AsyncWrapper`'s worker task, before the call to `self._args_buffer.task_done()`:
https://github.com/golemfactory/yapapi/blob/b16542ff5091cdb46f915d1f49f8f14af69ac495/yapapi/executor/utils.py#L34-L50

2. The `KeyboardInterrupt` is then handled correctly which leads to cancelling all `asyncio` tasks. Upon exiting from the main `Excecutor` task, `AsyncWrapper.stop()` is called:
https://github.com/golemfactory/yapapi/blob/b16542ff5091cdb46f915d1f49f8f14af69ac495/yapapi/executor/utils.py#L52-L57

3. Since one call to `self._args_buffer.task_done()` has been skipped due to `KeyboardInterrupt`, `self._args_buffer.join()` thinks one item is still being processed and thus hangs indefinitely.

Note: Pressing ctrl+c may cause `KeyboardInterrupt` to be raised in various `asyncio` tasks, depending on which one is currently executing, or in the event loop code itself. Therefore the above scenario occurs only occasionally when running `blender.py`, mainly of Windows machines (but has been observed on macos as well). See the unit test case `test_stop_doesnt_deadlock()` added in 0a8b72c on how to reproduce this scenario.

The solution is simply to place `self._args_buffer.task_done()` in a `finally` clause thus making sure that each `_args_buffer.get()` is followed by `_args_buffer.task_done()`.
  