### PR TITLE
Market strategy that decreases score for providers that fail to confirm agreements

### DIFF
--- a/yapapi/executor/agreements_pool.py
+++ b/yapapi/executor/agreements_pool.py
@@ -133,7 +133,7 @@ class AgreementsPool:
             emit(events.AgreementRejected(agr_id=agreement.id))
             self._failed_agreements.add(provider_id)
             return None
-        self._failed_agreements.remove(provider_id)
+        self._failed_agreements.discard(provider_id)
         self._agreements[agreement.id] = BufferedAgreement(
             agreement=agreement,
             node_info=node_info,

--- a/yapapi/executor/agreements_pool.py
+++ b/yapapi/executor/agreements_pool.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 import random
 import sys
-from typing import Dict, NamedTuple, Optional, Tuple
+from typing import Dict, NamedTuple, Optional, Set, Tuple
 
 from yapapi.executor import events
 from yapapi.props import Activity, NodeInfo
@@ -41,6 +41,8 @@ class AgreementsPool:
         self._offer_buffer: Dict[str, _BufferedProposal] = {}  # provider_id -> Proposal
         self._agreements: Dict[str, BufferedAgreement] = {}  # agreement_id -> Agreement
         self._lock = asyncio.Lock()
+        # The set of provider ids for which agreement creation failed
+        self._failed_agreements: Set[str] = set()
         self.confirmed = 0
 
     async def cycle(self):
@@ -129,7 +131,9 @@ class AgreementsPool:
         )
         if not await agreement.confirm():
             emit(events.AgreementRejected(agr_id=agreement.id))
+            self._failed_agreements.add(provider_id)
             return None
+        self._failed_agreements.remove(provider_id)
         self._agreements[agreement.id] = BufferedAgreement(
             agreement=agreement,
             node_info=node_info,
@@ -202,3 +206,7 @@ class AgreementsPool:
             buffered_agreement.worker_task and buffered_agreement.worker_task.cancel()
             del self._agreements[agr_id]
             self.emitter(events.AgreementTerminated(agr_id=agr_id, reason=reason))
+
+    def last_agreement_rejected(self, provider_id: str) -> bool:
+        """Return `True` iff the last agreement proposed to `provider_id` has been rejected."""
+        return provider_id in self._failed_agreements

--- a/yapapi/executor/strategy.py
+++ b/yapapi/executor/strategy.py
@@ -142,6 +142,7 @@ class DecreaseScoreForUnconfirmedAgreement(MarketStrategy):
     def __init__(self, base_strategy, factor):
         self._base_strategy = base_strategy
         self._factor = factor
+        self._logger = logging.getLogger(f"{__name__}.{type(self).__name__}")
 
     async def decorate_demand(self, demand: DemandBuilder) -> None:
         """Decorate `demand` using the base strategy."""
@@ -157,5 +158,6 @@ class DecreaseScoreForUnconfirmedAgreement(MarketStrategy):
         """
         score = await self._base_strategy.score_offer(offer)
         if history and history.last_agreement_rejected(offer.issuer):
+            self._logger.debug("Decreasing score for offer %s from '%s'", offer.id, offer.issuer)
             score *= self._factor
         return score

--- a/yapapi/executor/strategy.py
+++ b/yapapi/executor/strategy.py
@@ -12,7 +12,6 @@ from typing_extensions import Final, Protocol
 from ..props import com, Activity
 from ..props.builder import DemandBuilder
 from .. import rest
-from .agreements_pool import AgreementsPool
 
 
 SCORE_NEUTRAL: Final[float] = 0.0
@@ -27,7 +26,7 @@ CFF_DEFAULT_PRICE_FOR_COUNTER: Final[Mapping[com.Counter, Decimal]] = MappingPro
 class ComputationHistory(Protocol):
     """A protocol for objects that provide information about the history of current computation."""
 
-    def last_agreement_rejected(self, issuer_id) -> bool:
+    def rejected_last_agreement(self, issuer_id) -> bool:
         """Return True iff the previous agreement proposed to `issuer_id` has been rejected."""
         ...
 
@@ -157,7 +156,7 @@ class DecreaseScoreForUnconfirmedAgreement(MarketStrategy):
         then the base score is multiplied by `self._factor`.
         """
         score = await self._base_strategy.score_offer(offer)
-        if history and history.last_agreement_rejected(offer.issuer):
+        if history and history.rejected_last_agreement(offer.issuer) and score > 0:
             self._logger.debug("Decreasing score for offer %s from '%s'", offer.id, offer.issuer)
             score *= self._factor
         return score

--- a/yapapi/rest/market.py
+++ b/yapapi/rest/market.py
@@ -67,7 +67,7 @@ class Agreement(object):
         """
         await self._api.confirm_agreement(self._id)
         try:
-            await self._api.wait_for_approval(self._id, timeout=90, _request_timeout=100)
+            await self._api.wait_for_approval(self._id, timeout=15, _request_timeout=16)
             return True
         except ApiException:
             logger.debug("waitForApproval(%s) raised ApiException", self._id, exc_info=True)


### PR DESCRIPTION
Resolves #245 

A quick fix for #245. Adds two changes:
1. A `MarketStrategy` implementation that decreases score for offers from providers that failed to confirm previous agreement proposed to them.
2. Decreases timeout for `WaitForProposal` operation from 90s to 15s.

Note that 1 required a change in `MarketStrategy` public API, an optional `history` argument is added to the `score_offer` method:
```
    async def score_offer(
        self, offer: rest.market.OfferProposal, history: Optional[ComputationHistory] = None
    ) -> float:
```