### PR TITLE
Log payments to console; more verbose logging during shutdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.5.0-alpha.5"
+version = "0.5.0-alpha.6"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>", "GolemFactory <contact@golem.network>"]
 license = "LGPL-3.0-or-later"

--- a/yapapi/executor/strategy.py
+++ b/yapapi/executor/strategy.py
@@ -7,7 +7,7 @@ from types import MappingProxyType
 from typing import Mapping, Optional
 
 from dataclasses import dataclass, field
-from typing_extensions import Final
+from typing_extensions import Final, Protocol
 
 from ..props import com, Activity
 from ..props.builder import DemandBuilder
@@ -23,13 +23,23 @@ CFF_DEFAULT_PRICE_FOR_COUNTER: Final[Mapping[com.Counter, Decimal]] = MappingPro
 )
 
 
+class ComputationHistory(Protocol):
+    """A protocol for objects that provide information about the history of current computation."""
+
+    def rejected_last_agreement(self, issuer_id) -> bool:
+        """Return True iff the previous agreement proposed to `issuer_id` has been rejected."""
+        ...
+
+
 class MarketStrategy(abc.ABC):
     """Abstract market strategy."""
 
     async def decorate_demand(self, demand: DemandBuilder) -> None:
         """Optionally add relevant constraints to a Demand."""
 
-    async def score_offer(self, offer: rest.market.OfferProposal) -> float:
+    async def score_offer(
+        self, offer: rest.market.OfferProposal, history: Optional[ComputationHistory] = None
+    ) -> float:
         """Score `offer`. Better offers should get higher scores."""
         return SCORE_REJECTED
 
@@ -52,7 +62,9 @@ class DummyMS(MarketStrategy, object):
         demand.ensure(f"({com.PRICE_MODEL}={com.PriceModel.LINEAR.value})")
         self._activity = Activity.from_properties(demand.properties)
 
-    async def score_offer(self, offer: rest.market.OfferProposal) -> float:
+    async def score_offer(
+        self, offer: rest.market.OfferProposal, history: Optional[ComputationHistory] = None
+    ) -> float:
         """Score `offer`. Returns either `SCORE_REJECTED` or `SCORE_NEUTRAL`."""
 
         linear: com.ComLinear = com.ComLinear.from_properties(offer.props)
@@ -83,7 +95,9 @@ class LeastExpensiveLinearPayuMS(MarketStrategy, object):
         """Ensure that the offer uses `PriceModel.LINEAR` price model."""
         demand.ensure(f"({com.PRICE_MODEL}={com.PriceModel.LINEAR.value})")
 
-    async def score_offer(self, offer: rest.market.OfferProposal) -> float:
+    async def score_offer(
+        self, offer: rest.market.OfferProposal, history: Optional[ComputationHistory] = None
+    ) -> float:
         """Score `offer` according to cost for expected computation time."""
 
         linear: com.ComLinear = com.ComLinear.from_properties(offer.props)
@@ -115,4 +129,34 @@ class LeastExpensiveLinearPayuMS(MarketStrategy, object):
         # The higher the expected price value, the lower the score.
         # The score is always lower than SCORE_TRUSTED and is always higher than 0.
         score = SCORE_TRUSTED * 1.0 / (expected_price + 1.01)
+        return score
+
+
+class DecreaseScoreForUnconfirmedAgreement(MarketStrategy):
+    """A market strategy that modifies a base strategy based on history of agreements."""
+
+    _base_strategy: MarketStrategy
+    _factor: float
+
+    def __init__(self, base_strategy, factor):
+        self._base_strategy = base_strategy
+        self._factor = factor
+        self._logger = logging.getLogger(f"{__name__}.{type(self).__name__}")
+
+    async def decorate_demand(self, demand: DemandBuilder) -> None:
+        """Decorate `demand` using the base strategy."""
+        await self._base_strategy.decorate_demand(demand)
+
+    async def score_offer(
+        self, offer: rest.market.OfferProposal, history: Optional[ComputationHistory] = None
+    ) -> float:
+        """Score `offer` using the base strategy and apply penalty if needed.
+
+        If the offer issuer failed to approve the previous agreement (if any)
+        then the base score is multiplied by `self._factor`.
+        """
+        score = await self._base_strategy.score_offer(offer)
+        if history and history.rejected_last_agreement(offer.issuer) and score > 0:
+            self._logger.debug("Decreasing score for offer %s from '%s'", offer.id, offer.issuer)
+            score *= self._factor
         return score

--- a/yapapi/rest/market.py
+++ b/yapapi/rest/market.py
@@ -67,7 +67,7 @@ class Agreement(object):
         """
         await self._api.confirm_agreement(self._id)
         try:
-            await self._api.wait_for_approval(self._id, timeout=90, _request_timeout=100)
+            await self._api.wait_for_approval(self._id, timeout=15, _request_timeout=16)
             return True
         except ApiException:
             logger.debug("waitForApproval(%s) raised ApiException", self._id, exc_info=True)


### PR DESCRIPTION
Resolves #236
Resolves #244

Added lines are those with `Waiting for ...` and `Accepted invoice from ...`:
```
[2021-02-15 10:25:48,930 INFO yapapi.summary] Computation finished in 25.8s
[2021-02-15 10:25:48,931 INFO yapapi.summary] Negotiated 5 agreements with 5 providers
[2021-02-15 10:25:48,931 INFO yapapi.summary] Provider 'azathoth-rnd.4' computed 2 tasks
[2021-02-15 10:25:48,931 INFO yapapi.summary] Provider 'witek.4' computed 1 task
[2021-02-15 10:25:48,931 INFO yapapi.summary] Provider 'qbam.4' computed 1 task
[2021-02-15 10:25:48,931 INFO yapapi.summary] Provider 'mbenke.4' computed 1 task
[2021-02-15 10:25:48,931 INFO yapapi.summary] Provider '2rec-ubuntu.4' computed 1 task
[2021-02-15 10:25:49,935 INFO yapapi.executor] Waiting for 1 worker to finish...
[2021-02-15 10:25:51,521 INFO yapapi.executor] Waiting for all services to finish...
[2021-02-15 10:25:51,889 INFO yapapi.summary] Accepted invoice from 'witek.4', amount: 0.038675
[2021-02-15 10:25:52,009 INFO yapapi.summary] Accepted invoice from 'qbam.4', amount: 0.056360
[2021-02-15 10:25:52,199 INFO yapapi.summary] Accepted invoice from '2rec-ubuntu.4', amount: 0.030545
[2021-02-15 10:25:52,441 INFO yapapi.summary] Accepted invoice from 'mbenke.4', amount: 0.038206
[2021-02-15 10:25:52,522 INFO yapapi.executor] 1 agreement still unpaid, waiting for invoices...
[2021-02-15 10:25:52,737 INFO yapapi.summary] Accepted invoice from 'azathoth-rnd.4', amount: 0.053563
6 tasks computed, total time: 0:00:29.914873
[2021-02-15 10:25:52,757 INFO yapapi.summary] Total cost: 0.21734953999
[2021-02-15 10:25:52,758 INFO yapapi.summary] Executor has shut down
```