### PR TITLE
Don't publish duplicates with gftp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.5.1-alpha.1"
+version = "0.5.1-alpha.2"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>", "GolemFactory <contact@golem.network>"]
 license = "LGPL-3.0-or-later"


### PR DESCRIPTION
Resolves #252 

This PR modifies the `gftp` storage provider so that it stores SHA3_256 digests of all the files that have already been published by this storage provider instance and only publishes the files with yet unknown digests.
 
