### PR TITLE
Improvements and fixes in the summary logger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.5.1-alpha.2"
+version = "0.5.1-alpha.3"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>", "GolemFactory <contact@golem.network>"]
 license = "LGPL-3.0-or-later"


### PR DESCRIPTION
Resolves #263

Task data is trimmed to 200 characters in the summary logger.
Note that low-level loggers used to output debug logs to a file will still print the whole string.

Resolves #257

The summary logger will represent amounts as instances of `Decimal`, so exact amounts, as included in invoices, will be printed.

Resolves #256 
