### PR TITLE
Handle break statement in async for ... in executor.submit(...)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.5.1-alpha.3"
+version = "0.5.1-alpha.4"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>", "GolemFactory <contact@golem.network>"]
 license = "LGPL-3.0-or-later"


### PR DESCRIPTION
This PR adds handling of the `break` statement in `async for` loops that iterate over asynchronous generators returned by `Executor.submit()`, like this:
```
    async for task in executor.submit(worker, tasks):
        if task.result == 42:
            break
```

Currently, `break` will cause the computation started by `executor.submit(...)` to be shut down immediately, without destroying activities, terminating agreements, waiting for invoices. 

This is caused by 
1. not handling `GeneratorExit` (raised on `break`) in `Executor.submit()`;
2. not waiting until `Executor.submit()` finishes before shutting down the executor in `Executor.__aexit__()`.

The current PR:
1. adds proper handling of `GeneratorExit` in `Executor.submit()`;
2. adds a synchronisation mechanism for ensuring that executor shutdown in `Executor.__aexit__()` is performed only after all computations started by `Executor.submit()` are finished.

The resulting semantics is that the `break` statement causes `CancelledError` to be raised inside the asynchronous generator being iterated over by the enclosing `async for` loop. The computation performed by the generator is then gracefully terminated.

EDIT: Additional changes in `SummaryLogger`:

1. Cancelling a computation is currently reported as an `ERROR`:
    ```
   [2021-02-24 11:59:05,540 ERROR yapapi.summary] Computation failed, reason: CancelledError()
    ```
   This PR changes this to:
    ```
   [2021-02-24 11:59:05,540 WARNING yapapi.summary] Computation cancelled
    ```
   which is more appropriate, since the cancellation is typically the result of the user pressing ctrl+C or using the `break` statment.

2. Computation summary with the number of agreements negotiated and numbers of tasks computed by each provider is currently printed only after the computation finishes without errors and is not cancelled -- which is probably just an omission. This PR changes this to print the summary also when the computation is cancelled or stopped by errors.



   