### PR TITLE
add `WorkContext.send_bytes` command

### DIFF
--- a/tests/executor/test_ctx.py
+++ b/tests/executor/test_ctx.py
@@ -1,5 +1,12 @@
-from yapapi.executor.ctx import CommandContainer
+import factory
 import json
+import pytest
+import sys
+from unittest import mock
+
+from yapapi.executor.ctx import CommandContainer, WorkContext
+
+from tests.factories.props import NodeInfoFactory
 
 
 def test_command_container():
@@ -29,3 +36,51 @@ def test_command_container():
     ]
     """
     assert json.loads(expected_commands) == c.commands()
+
+
+class TestWorkContext:
+    @staticmethod
+    def _get_work_context(storage):
+        return WorkContext(
+            factory.Faker("pystr"),
+            node_info=NodeInfoFactory(),
+            storage=storage
+        )
+
+    @staticmethod
+    def _assert_dst_path(steps, dst_path):
+        c = CommandContainer()
+        steps.register(c)
+        assert c.commands().pop()['transfer']['to'] == f"container:{dst_path}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8), reason="AsyncMock requires python 3.8+"
+    )
+    async def test_send_json(self):
+        storage = mock.AsyncMock()
+        dst_path = "/test/path"
+        data = {
+            'param': 'value',
+        }
+        ctx = self._get_work_context(storage)
+        ctx.send_json(dst_path, data)
+        steps = ctx.commit()
+        await steps.prepare()
+        storage.upload_bytes.assert_called_with(json.dumps(data).encode("utf-8"))
+        self._assert_dst_path(steps, dst_path)
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8), reason="AsyncMock requires python 3.8+"
+    )
+    async def test_send_bytes(self):
+        storage = mock.AsyncMock()
+        dst_path = "/test/path"
+        data = b"some byte string"
+        ctx = self._get_work_context(storage)
+        ctx.send_bytes(dst_path, data)
+        steps = ctx.commit()
+        await steps.prepare()
+        storage.upload_bytes.assert_called_with(data)
+        self._assert_dst_path(steps, dst_path)

--- a/tests/executor/test_ctx.py
+++ b/tests/executor/test_ctx.py
@@ -41,27 +41,21 @@ def test_command_container():
 class TestWorkContext:
     @staticmethod
     def _get_work_context(storage):
-        return WorkContext(
-            factory.Faker("pystr"),
-            node_info=NodeInfoFactory(),
-            storage=storage
-        )
+        return WorkContext(factory.Faker("pystr"), node_info=NodeInfoFactory(), storage=storage)
 
     @staticmethod
     def _assert_dst_path(steps, dst_path):
         c = CommandContainer()
         steps.register(c)
-        assert c.commands().pop()['transfer']['to'] == f"container:{dst_path}"
+        assert c.commands().pop()["transfer"]["to"] == f"container:{dst_path}"
 
     @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8), reason="AsyncMock requires python 3.8+"
-    )
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="AsyncMock requires python 3.8+")
     async def test_send_json(self):
         storage = mock.AsyncMock()
         dst_path = "/test/path"
         data = {
-            'param': 'value',
+            "param": "value",
         }
         ctx = self._get_work_context(storage)
         ctx.send_json(dst_path, data)
@@ -71,9 +65,7 @@ class TestWorkContext:
         self._assert_dst_path(steps, dst_path)
 
     @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8), reason="AsyncMock requires python 3.8+"
-    )
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="AsyncMock requires python 3.8+")
     async def test_send_bytes(self):
         storage = mock.AsyncMock()
         dst_path = "/test/path"

--- a/tests/factories/props/__init__.py
+++ b/tests/factories/props/__init__.py
@@ -1,0 +1,11 @@
+import factory
+
+from yapapi.props import NodeInfo
+
+
+class NodeInfoFactory(factory.Factory):
+    class Meta:
+        model = NodeInfo
+
+    name = factory.Faker("pystr")
+    subnet_tag = "devnet-beta.1"

--- a/yapapi/executor/ctx.py
+++ b/yapapi/executor/ctx.py
@@ -237,7 +237,7 @@ class WorkContext:
         """Schedule sending bytes data to the provider.
 
         :param dst_path: remote (provider) path
-        :param data: dictionary representing JSON data
+        :param data: bytes to send
         :return: None
         """
         self.__prepare()

--- a/yapapi/executor/ctx.py
+++ b/yapapi/executor/ctx.py
@@ -76,18 +76,21 @@ class _SendWork(Work, abc.ABC):
         )
 
 
-class _SendJson(_SendWork):
-    def __init__(self, storage: StorageProvider, data: dict, dst_path: str):
+class _SendBytes(_SendWork):
+    def __init__(self, storage: StorageProvider, data: bytes, dst_path: str):
         super().__init__(storage, dst_path)
-        self._cnt = 0
-        self._data: Optional[bytes] = json.dumps(data).encode(encoding="utf-8")
+        self._data: Optional[bytes] = data
 
     async def do_upload(self, storage: StorageProvider) -> Source:
-        self._cnt += 1
-        assert self._data is not None, f"json buffer unintialized {self._cnt}"
+        assert self._data is not None, f"buffer unintialized"
         src = await storage.upload_bytes(self._data)
         self._data = None
         return src
+
+
+class _SendJson(_SendBytes):
+    def __init__(self, storage: StorageProvider, data: dict, dst_path: str):
+        super().__init__(storage, json.dumps(data).encode(encoding="utf-8"), dst_path)
 
 
 class _SendFile(_SendWork):
@@ -229,6 +232,16 @@ class WorkContext:
         """
         self.__prepare()
         self._pending_steps.append(_SendJson(self._storage, data, json_path))
+
+    def send_bytes(self, dst_path: str, data: bytes):
+        """Schedule sending bytes data to the provider.
+
+        :param dst_path: remote (provider) path
+        :param data: dictionary representing JSON data
+        :return: None
+        """
+        self.__prepare()
+        self._pending_steps.append(_SendBytes(self._storage, data, dst_path))
 
     def send_file(self, src_path: str, dst_path: str):
         """Schedule sending file to the provider.


### PR DESCRIPTION
add a `send_bytes` command to WorkContext to enable e.g. sending simple scripts directly, without having to create intermediate files to contain them
