### PR TITLE
Handle ApiException caused by subscription expiration

### DIFF
--- a/tests/goth/test_resubscription.py
+++ b/tests/goth/test_resubscription.py
@@ -1,0 +1,175 @@
+"""Test if subscription expiration is handled correctly by Executor"""
+from datetime import timedelta
+import logging
+import os
+from pathlib import Path
+import time
+from typing import Dict, Set
+from unittest.mock import Mock
+
+import colors
+import pytest
+
+from goth.assertions import EventStream
+from goth.assertions.monitor import EventMonitor
+from goth.assertions.operators import eventually
+
+from goth.configuration import load_yaml
+from goth.runner import Runner
+from goth.runner.log import configure_logging, monitored_logger
+from goth.runner.probe import RequestorProbe
+
+from yapapi import Executor, Task
+from yapapi.executor.events import (
+    Event,
+    ComputationStarted,
+    ComputationFinished,
+    SubscriptionCreated,
+)
+import yapapi.rest.market
+from yapapi.log import enable_default_logger
+from yapapi.package import vm
+
+import ya_market.api.requestor_api
+from ya_market import ApiException
+
+logger = logging.getLogger("goth.test")
+
+SUBSCRIPTION_EXPIRATION_TIME = 5
+"""Number of seconds after which a subscription expires"""
+
+
+class RequestorApi(ya_market.api.requestor_api.RequestorApi):
+    """A replacement for market API that simulates early subscription expiration.
+
+    A call to `collect_offers(sub_id)` will raise `ApiException` indicating
+    subscription expiration when at least `SUBSCRIPTION_EXPIRATION_TIME`
+    elapsed after the given subscription has been created.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.subscriptions: Dict[str, float] = {}
+
+    def subscribe_demand(self, demand, **kwargs):
+        """Override `RequestorApi.subscribe_demand()` to register subscription create time."""
+        id_coro = super().subscribe_demand(demand, **kwargs)
+
+        async def coro():
+            id = await id_coro
+            self.subscriptions[id] = time.time()
+            return id
+
+        return coro()
+
+    def collect_offers(self, subscription_id, **kwargs):
+        """Override `RequestorApi.collect_offers()`.
+
+        Raise `ApiException(404)` if at least `SUBSCRIPTION_EXPIRATION_TIME` elapsed
+        since the subscription identified by `subscription_id` has been created.
+        """
+        if time.time() > self.subscriptions[subscription_id] + SUBSCRIPTION_EXPIRATION_TIME:
+            logger.info("Subscription expired")
+
+            async def coro():
+                raise ApiException(
+                    http_resp=Mock(
+                        status=404,
+                        reason="Not Found",
+                        data=f"{{'message': 'Subscription [{subscription_id}] expired.'}}",
+                    )
+                )
+
+            return coro()
+        else:
+            return super().collect_offers(subscription_id, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def patch_collect_offers(monkeypatch):
+    """Install the patched `RequestorApi` class."""
+    monkeypatch.setattr(yapapi.rest.market, "RequestorApi", RequestorApi)
+
+
+@pytest.mark.asyncio
+async def test_resubmission(log_dir: Path, monkeypatch) -> None:
+    """Test that a demand is re-submitted after the previous submission expires."""
+
+    configure_logging(log_dir)
+
+    goth_config = load_yaml(Path(__file__).parent / "assets" / "goth-config.yml")
+
+    vm_package = await vm.repo(
+        image_hash="9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+        min_mem_gib=0.5,
+        min_storage_gib=2.0,
+    )
+
+    runner = Runner(base_log_dir=log_dir, compose_config=goth_config.compose_config)
+
+    containers = [
+        container for container in goth_config.containers if container.name != "provider-2"
+    ]
+
+    async def assertion(events: "EventStream[Event]"):
+        """A temporal assertion that the requestor has to satisfy.
+
+        It states that a `SubscriptionCreated` event occurs at least
+        three times during requestor execution.
+        """
+        subscription_ids: Set[str] = set()
+
+        e = await eventually(events, lambda e: isinstance(e, ComputationStarted), 10)
+        assert e, "Timed out waiting for ComputationStarted"
+        logger.info(colors.cyan(str(e)))
+
+        while len(subscription_ids) < 3:
+            e = await eventually(events, lambda e: isinstance(e, SubscriptionCreated), 15)
+            assert isinstance(e, SubscriptionCreated), "Timed out waiting for SubscriptionCreated"
+            logger.info(colors.cyan(str(e)))
+            assert e.sub_id not in subscription_ids
+            subscription_ids.add(e.sub_id)
+
+        e = await eventually(events, lambda e: isinstance(e, ComputationFinished), 20)
+        assert e, "Timed out waiting for ComputationFailed"
+        logger.info(colors.cyan(str(e)))
+
+    async with runner(containers):
+
+        requestor = runner.get_probes(probe_type=RequestorProbe)[0]
+        env = {**os.environ}
+        requestor.set_agent_env_vars(env)
+
+        # Setup the environment for the requestor
+        for key, val in env.items():
+            monkeypatch.setenv(key, val)
+
+        monitor = EventMonitor()
+        monitor.add_assertion(assertion)
+        monitor.start()
+
+        # The requestor
+
+        enable_default_logger()
+
+        async def worker(work_ctx, tasks):
+            async for task in tasks:
+                work_ctx.run("/bin/sleep", "5")
+                yield work_ctx.commit()
+                task.accept_result()
+
+        async with Executor(
+            budget=10.0,
+            package=vm_package,
+            max_workers=1,
+            timeout=timedelta(seconds=25),
+            event_consumer=monitor.add_event_sync,
+        ) as executor:
+
+            task: Task  # mypy needs this for some reason
+            async for task in executor.submit(worker, [Task(data=n) for n in range(20)]):
+                logger.info("Task %d computed", task.data)
+
+        await monitor.stop()
+        for a in monitor.failed:
+            raise a.result()

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -36,7 +36,6 @@ from .task import Task, TaskStatus
 from .utils import AsyncWrapper
 from ..package import Package
 from ..props import Activity, com, NodeInfo, NodeInfoKeys
-from ..props.base import InvalidPropertiesError
 from ..props.builder import DemandBuilder
 from .. import rest
 from ..rest.activity import CommandExecutionError
@@ -337,8 +336,8 @@ class Executor(AsyncContextManager):
                             note_id=debit_note.debit_note_id,
                         )
                     )
-                    allocation = self._get_allocation(debit_note)
                     try:
+                        allocation = self._get_allocation(debit_note)
                         await debit_note.accept(
                             amount=debit_note.total_amount_due, allocation=allocation
                         )
@@ -751,7 +750,7 @@ class Executor(AsyncContextManager):
                 and allocation.payment_platform == item.payment_platform
             )
         except:
-            raise RuntimeError(f"No allocation for {item.payment_platform} {item.payer_addr}.")
+            raise ValueError(f"No allocation for {item.payment_platform} {item.payer_addr}.")
 
     async def __aenter__(self) -> "Executor":
         stack = self._stack

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -3,7 +3,6 @@ An implementation of the new Golem's task executor.
 """
 import asyncio
 from asyncio import CancelledError
-import contextlib
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 import logging
@@ -39,6 +38,7 @@ from ..props import Activity, com, NodeInfo, NodeInfoKeys
 from ..props.builder import DemandBuilder
 from .. import rest
 from ..rest.activity import CommandExecutionError
+from ..rest.market import Subscription
 from ..storage import gftp
 from ._smartq import SmartQueue, Handle
 from .strategy import (
@@ -368,7 +368,7 @@ class Executor(AsyncContextManager):
                 )
             )
 
-        async def find_offers() -> None:
+        async def find_offers_for_subscription(subscription: Subscription) -> None:
             """Subscribe to offers and process them continuously."""
 
             async def reject_proposal(proposal, reason):
@@ -376,74 +376,81 @@ class Executor(AsyncContextManager):
                 emit(events.ProposalRejected(prop_id=proposal.id, reason=reason))
 
             nonlocal offers_collected, proposals_confirmed
+
+            emit(events.SubscriptionCreated(sub_id=subscription.id))
             try:
-                subscription = await builder.subscribe(market_api)
+                proposals = subscription.events()
             except Exception as ex:
-                emit(events.SubscriptionFailed(reason=str(ex)))
+                emit(events.CollectFailed(sub_id=subscription.id, reason=str(ex)))
                 raise
 
-            async with subscription:
+            async for proposal in proposals:
 
-                emit(events.SubscriptionCreated(sub_id=subscription.id))
+                emit(events.ProposalReceived(prop_id=proposal.id, provider_id=proposal.issuer))
+                offers_collected += 1
                 try:
-                    proposals = subscription.events()
-                except Exception as ex:
-                    emit(events.CollectFailed(sub_id=subscription.id, reason=str(ex)))
-                    raise
+                    score = await strategy.score_offer(proposal, agreements_pool)
+                    logger.debug(
+                        "Scored offer %s, provider: %s, strategy: %s, score: %f",
+                        proposal.id,
+                        proposal.props.get("golem.node.id.name"),
+                        type(strategy).__name__,
+                        score,
+                    )
 
-                async for proposal in proposals:
+                    if score < SCORE_NEUTRAL:
+                        await reject_proposal(proposal, "Score too low")
 
-                    emit(events.ProposalReceived(prop_id=proposal.id, provider_id=proposal.issuer))
-                    offers_collected += 1
-                    try:
-                        score = await strategy.score_offer(proposal, agreements_pool)
-                        logger.debug(
-                            "Scored offer %s, provider: %s, strategy: %s, score: %f",
-                            proposal.id,
-                            proposal.props.get("golem.node.id.name"),
-                            type(strategy).__name__,
-                            score,
-                        )
-
-                        if score < SCORE_NEUTRAL:
-                            await reject_proposal(proposal, "Score too low")
-
-                        elif not proposal.is_draft:
-                            common_platforms = self._get_common_payment_platforms(proposal)
-                            if common_platforms:
-                                builder.properties["golem.com.payment.chosen-platform"] = next(
-                                    iter(common_platforms)
-                                )
-                            else:
-                                # reject proposal if there are no common payment platforms
-                                await reject_proposal(proposal, "No common payment platform")
-                                continue
-                            timeout = proposal.props.get(DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP)
-                            if timeout:
-                                if timeout < DEBIT_NOTE_MIN_TIMEOUT:
-                                    await reject_proposal(
-                                        proposal, "Debit note acceptance timeout too short"
-                                    )
-                                    continue
-                                else:
-                                    builder.properties[DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP] = timeout
-
-                            await proposal.respond(builder.properties, builder.constraints)
-                            emit(events.ProposalResponded(prop_id=proposal.id))
-
-                        else:
-                            emit(events.ProposalConfirmed(prop_id=proposal.id))
-                            await agreements_pool.add_proposal(score, proposal)
-                            proposals_confirmed += 1
-
-                    except CancelledError:
-                        raise
-                    except Exception:
-                        emit(
-                            events.ProposalFailed(
-                                prop_id=proposal.id, exc_info=sys.exc_info()  # type: ignore
+                    elif not proposal.is_draft:
+                        common_platforms = self._get_common_payment_platforms(proposal)
+                        if common_platforms:
+                            builder.properties["golem.com.payment.chosen-platform"] = next(
+                                iter(common_platforms)
                             )
+                        else:
+                            # reject proposal if there are no common payment platforms
+                            await reject_proposal(proposal, "No common payment platform")
+                            continue
+                        timeout = proposal.props.get(DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP)
+                        if timeout:
+                            if timeout < DEBIT_NOTE_MIN_TIMEOUT:
+                                await reject_proposal(
+                                    proposal, "Debit note acceptance timeout too short"
+                                )
+                                continue
+                            else:
+                                builder.properties[DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP] = timeout
+
+                        await proposal.respond(builder.properties, builder.constraints)
+                        emit(events.ProposalResponded(prop_id=proposal.id))
+
+                    else:
+                        emit(events.ProposalConfirmed(prop_id=proposal.id))
+                        await agreements_pool.add_proposal(score, proposal)
+                        proposals_confirmed += 1
+
+                except CancelledError:
+                    raise
+                except Exception:
+                    emit(
+                        events.ProposalFailed(
+                            prop_id=proposal.id, exc_info=sys.exc_info()  # type: ignore
                         )
+                    )
+
+        async def find_offers() -> None:
+            """Create demand subscription and process offers.
+
+            When the subscription expires, create a new one. And so on...
+            """
+            while True:
+                try:
+                    subscription = await builder.subscribe(market_api)
+                except Exception as ex:
+                    emit(events.SubscriptionFailed(reason=str(ex)))
+                    raise
+                async with subscription:
+                    await find_offers_for_subscription(subscription)
 
         # aio_session = await self._stack.enter_async_context(aiohttp.ClientSession())
         # storage_manager = await DavStorageProvider.for_directory(

--- a/yapapi/rest/market.py
+++ b/yapapi/rest/market.py
@@ -207,9 +207,10 @@ class Subscription(object):
             try:
                 proposals = await self._api.collect_offers(self._id, timeout=10, max_events=10)
             except ApiException as ex:
-                if ex.status == 404 and re.search("Subscription .* expired", ex.body or ""):
-                    logger.warning(
-                        "Subscription has expired, no new offers will be collected from now on"
+                if ex.status == 404:
+                    logger.debug(
+                        "Offer unsubscribed or its subscription expired, subscription_id: %s",
+                        self._id,
                     )
                     self._open = False
                     # Prevent calling `unsubscribe` which would result in API error

--- a/yapapi/rest/market.py
+++ b/yapapi/rest/market.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import re
 from types import TracebackType
 from typing import AsyncIterator, Optional, TypeVar, Type, Generator, Any, Generic
 
@@ -202,7 +203,22 @@ class Subscription(object):
     async def events(self) -> AsyncIterator[OfferProposal]:
         """Yield counter-proposals based on the incoming, matching Offers."""
         while self._open:
-            proposals = await self._api.collect_offers(self._id, timeout=10, max_events=10)
+
+            try:
+                proposals = await self._api.collect_offers(self._id, timeout=10, max_events=10)
+            except ApiException as ex:
+                if ex.status == 404 and re.search("Subscription .* expired", ex.body or ""):
+                    logger.warning(
+                        "Subscription has expired, no new offers will be collected from now on"
+                    )
+                    self._open = False
+                    # Prevent calling `unsubscribe` which would result in API error
+                    # for expired demand subscriptione
+                    self._deleted = True
+                    continue
+                else:
+                    raise
+
             for proposal in proposals:
                 if isinstance(proposal, models.ProposalEvent):
                     yield OfferProposal(self, proposal)


### PR DESCRIPTION
Resolves #340

Changes in this PR:
- Every time `collectOffers` raises `ApiException(404)` a new subscription is created for the demand created by `Executor.submit()`; thus the computation may continue and new offers will be collected from the market.
- An integration test (using `goth` and some mocking) is added in`tests/goth/test_resubmission.py`.