### PR TITLE
Specify `yagna` version used in `goth` tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ ya-market = "0.1.0"
 [tool.poe.tasks]
 test = "pytest --cov=yapapi --ignore tests/goth"
 goth-assets = "python -m goth create-assets tests/goth/assets"
-goth-tests = "pytest -svx tests/goth"
+goth-tests = "pytest -svx tests/goth --config-override docker-compose.build-environment.release-tag=0.6."
 typecheck = "mypy ."
 codestyle = "black --check --diff ."
 _liccheck_export = "poetry export -E cli -f requirements.txt -o .requirements.txt"

--- a/tests/goth/conftest.py
+++ b/tests/goth/conftest.py
@@ -1,7 +1,37 @@
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import cast, List, Tuple
 
 import pytest
+
+from goth.configuration import Override
+from yapapi.package import Package, vm
+
+
+def pytest_addoption(parser):
+    """Add optional parameters to pytest CLI invocations."""
+
+    parser.addoption(
+        "--config-override",
+        action="append",
+        help="Set an override for a value specified in goth-config.yml file. \
+                This argument may be used multiple times. \
+                Values must follow the convention: {yaml_path}={value}, e.g.: \
+                `docker-compose.build-environment.release-tag=0.6.`",
+    )
+
+
+@pytest.fixture(scope="function")
+def config_overrides(request) -> List[Override]:
+    """Fixture parsing --config-override params passed to the test invocation.
+
+    This fixture has "function" scope, which means that each test function will
+    receive its own copy of the list of config overrides and may modify it at will,
+    without affecting other test functions run in the same session.
+    """
+
+    overrides: List[str] = request.config.option.config_override or []
+    return cast(List[Override], [tuple(o.split("=", 1)) for o in overrides])
 
 
 @pytest.fixture(scope="session")
@@ -17,3 +47,15 @@ def log_dir() -> Path:
     log_dir = base_dir / f"goth_{date_str}"
     log_dir.mkdir(parents=True)
     return log_dir
+
+
+@pytest.fixture()
+def blender_vm_package():
+    async def coro():
+        return await vm.repo(
+            image_hash="9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+            min_mem_gib=0.5,
+            min_storage_gib=2.0,
+        )
+
+    return coro()

--- a/tests/goth/test_agreement_termination/test_agreement_termination.py
+++ b/tests/goth/test_agreement_termination/test_agreement_termination.py
@@ -61,10 +61,14 @@ async def assert_all_tasks_computed(stream):
 async def test_agreement_termination(
     project_dir: Path,
     log_dir: Path,
+    config_overrides,
 ) -> None:
 
     # This is the default configuration with 2 wasm/VM providers
-    goth_config = load_yaml(project_dir / "tests" / "goth" / "assets" / "goth-config.yml")
+    goth_config = load_yaml(
+        project_dir / "tests" / "goth" / "assets" / "goth-config.yml",
+        config_overrides,
+    )
     test_script_path = str(Path(__file__).parent / "requestor.py")
 
     configure_logging(log_dir)

--- a/tests/goth/test_run_blender.py
+++ b/tests/goth/test_run_blender.py
@@ -75,13 +75,12 @@ async def assert_all_invoices_accepted(output_lines: EventStream[str]):
 
 
 @pytest.mark.asyncio
-async def test_run_blender(
-    log_dir: Path,
-    project_dir: Path,
-) -> None:
+async def test_run_blender(log_dir: Path, project_dir: Path, config_overrides) -> None:
 
     # This is the default configuration with 2 wasm/VM providers
-    goth_config = load_yaml(Path(__file__).parent / "assets" / "goth-config.yml")
+    goth_config = load_yaml(
+        Path(__file__).parent / "assets" / "goth-config.yml", overrides=config_overrides
+    )
 
     blender_path = project_dir / "examples" / "blender" / "blender.py"
 


### PR DESCRIPTION
The changes are cherry-picked from https://github.com/golemfactory/yapapi/pull/350