### PR TITLE
Repeat API calls on timeouts

### DIFF
--- a/tests/rest/test_repeat_on_timeout.py
+++ b/tests/rest/test_repeat_on_timeout.py
@@ -1,0 +1,59 @@
+import asyncio
+
+import pytest
+
+import ya_activity
+import ya_market
+import ya_payment
+
+from yapapi.rest.common import repeat_on_timeout
+
+
+@pytest.mark.parametrize(
+    "max_tries, exceptions, calls_expected, expected_error",
+    [
+        (1, [], 1, None),
+        (1, [asyncio.TimeoutError()], 1, asyncio.TimeoutError),
+        (1, [ya_activity.ApiException(408)], 1, ya_activity.ApiException),
+        (1, [ya_activity.ApiException(500)], 1, ya_activity.ApiException),
+        (1, [ValueError()], 1, ValueError),
+        #
+        (2, [], 1, None),
+        (2, [asyncio.TimeoutError()], 2, None),
+        (2, [ya_activity.ApiException(408)], 2, None),
+        (2, [ya_market.ApiException(408)], 2, None),
+        (2, [ya_payment.ApiException(408)], 2, None),
+        (2, [ya_activity.ApiException(500)], 1, ya_activity.ApiException),
+        (2, [ValueError()], 1, ValueError),
+        (2, [asyncio.TimeoutError()] * 2, 2, asyncio.TimeoutError),
+        #
+        (3, [], 1, None),
+        (3, [asyncio.TimeoutError()], 2, None),
+        (3, [ya_activity.ApiException(408)], 2, None),
+        (3, [asyncio.TimeoutError()] * 2, 3, None),
+        (3, [asyncio.TimeoutError()] * 3, 3, asyncio.TimeoutError),
+        (3, [ya_activity.ApiException(500)], 1, ya_activity.ApiException),
+        (3, [asyncio.TimeoutError(), ValueError()], 2, ValueError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_repeat_on_timeout(max_tries, exceptions, calls_expected, expected_error):
+
+    calls_made = 0
+
+    @repeat_on_timeout(max_tries=max_tries)
+    async def request():
+        nonlocal calls_made, exceptions
+        calls_made += 1
+        if exceptions:
+            e = exceptions[0]
+            exceptions = exceptions[1:]
+            raise e
+        return True
+
+    try:
+        await request()
+    except Exception as e:
+        assert expected_error is not None, f"Unexpected exception: {e}"
+        assert isinstance(e, expected_error), f"Expected an {expected_error}, got {e}"
+    assert calls_made == calls_expected, "{calls_made} attempts were made, expected {num_calls}"

--- a/yapapi/rest/common.py
+++ b/yapapi/rest/common.py
@@ -18,7 +18,7 @@ def is_intermittent_error(e: Exception) -> bool:
 
     is_timeout_exception = isinstance(e, asyncio.TimeoutError) or (
         isinstance(e, (ya_activity.ApiException, ya_market.ApiException, ya_payment.ApiException))
-        and e.status == 408
+        and e.status in (408, 504)
     )
 
     return (

--- a/yapapi/rest/common.py
+++ b/yapapi/rest/common.py
@@ -1,6 +1,10 @@
 import asyncio
+import contextlib
 import functools
 import logging
+from typing import Callable, Optional
+
+import aiohttp
 
 import ya_market
 import ya_activity
@@ -10,7 +14,7 @@ import ya_payment
 logger = logging.getLogger(__name__)
 
 
-def _is_timeout_exception(e: Exception) -> bool:
+def is_timeout_exception(e: Exception) -> bool:
     """Check if `e` indicates a client-side or server-side timeout error."""
 
     # `asyncio.TimeoutError` is raised on client-side timeouts
@@ -22,6 +26,38 @@ def _is_timeout_exception(e: Exception) -> bool:
         return e.status == 408
 
     return False
+
+
+def is_recoverable_exception(e: Exception) -> bool:
+    """Check if `e` indicates that we should retry the operation that raised it."""
+
+    return is_timeout_exception(e) or isinstance(e, aiohttp.ServerDisconnectedError)
+
+
+class SuppressedExceptions(contextlib.AbstractAsyncContextManager):
+    """An async context manager for suppressing exception satisfying given test function."""
+
+    exception: Optional[Exception]
+
+    def __init__(
+        self, should_suppress: Callable[[Exception], bool], report_exceptions: bool = True
+    ):
+        self._should_suppress = should_suppress
+        self._report_exceptions = report_exceptions
+        self.exception = None
+
+    async def __aenter__(self) -> "SuppressedExceptions":
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        if exc_value and self._should_suppress(exc_value):
+            self.exception = exc_value
+            if self._report_exceptions:
+                logger.debug(
+                    "Exception suppressed: %r", exc_value, exc_info=(exc_type, exc_value, traceback)
+                )
+            return True
+        return False
 
 
 def repeat_on_timeout(max_tries: int, interval: float = 0.0):
@@ -36,18 +72,18 @@ def repeat_on_timeout(max_tries: int, interval: float = 0.0):
 
                 if try_num > 1:
                     await asyncio.sleep(interval)
-                try:
+
+                async with SuppressedExceptions(is_timeout_exception, False) as se:
                     return await func(*args, **kwargs)
-                except Exception as e:
-                    if _is_timeout_exception(e):
-                        repeat = try_num < max_tries
-                        msg = f"API call timed out (attempt {try_num}/{max_tries}), "
-                        msg += f"retrying in {interval} s" if repeat else "giving up"
-                        # Don't print traceback if this was the last attempt, let the caller do it.
-                        logger.debug(msg, exc_info=repeat)
-                        if repeat:
-                            continue
-                    raise
+
+                assert se.exception  # noqa (unreachable)
+                repeat = try_num < max_tries
+                msg = f"API call timed out (attempt {try_num}/{max_tries}), "
+                msg += f"retrying in {interval} s" if repeat else "giving up"
+                # Don't print traceback if this was the last attempt, let the caller do it.
+                logger.debug(msg, exc_info=repeat)
+                if not repeat:
+                    raise se.exception
 
         return wrapper
 

--- a/yapapi/rest/common.py
+++ b/yapapi/rest/common.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import functools
 import logging
 from typing import Callable, Optional
@@ -34,7 +33,7 @@ def is_recoverable_exception(e: Exception) -> bool:
     return is_timeout_exception(e) or isinstance(e, aiohttp.ServerDisconnectedError)
 
 
-class SuppressedExceptions(contextlib.AbstractAsyncContextManager):
+class SuppressedExceptions:
     """An async context manager for suppressing exception satisfying given test function."""
 
     exception: Optional[Exception]

--- a/yapapi/rest/common.py
+++ b/yapapi/rest/common.py
@@ -1,0 +1,54 @@
+import asyncio
+import functools
+import logging
+
+import ya_market
+import ya_activity
+import ya_payment
+
+
+logger = logging.getLogger(__name__)
+
+
+def _is_timeout_exception(e: Exception) -> bool:
+    """Check if `e` indicates a client-side or server-side timeout error."""
+
+    # `asyncio.TimeoutError` is raised on client-side timeouts
+    if isinstance(e, asyncio.TimeoutError):
+        return True
+
+    # `ApiException(408)` is raised on server-side timeouts
+    if isinstance(e, (ya_activity.ApiException, ya_market.ApiException, ya_payment.ApiException)):
+        return e.status == 408
+
+    return False
+
+
+def repeat_on_timeout(max_tries: int, interval: float = 0.0):
+    """Decorate a function to repeat calls up to `max_tries` times when timeout errors occur."""
+
+    def decorator(func):
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            """Make at most `max_tries` attempts to call `func`."""
+
+            for try_num in range(1, max_tries + 1):
+
+                if try_num > 1:
+                    await asyncio.sleep(interval)
+                try:
+                    return await func(*args, **kwargs)
+                except Exception as e:
+                    if _is_timeout_exception(e):
+                        repeat = try_num < max_tries
+                        msg = f"API call timed out (attempt {try_num}/{max_tries}), "
+                        msg += f"retrying in {interval} s" if repeat else "giving up"
+                        # Don't print traceback if this was the last attempt, let the caller do it.
+                        logger.debug(msg, exc_info=repeat)
+                        if repeat:
+                            continue
+                    raise
+
+        return wrapper
+
+    return decorator

--- a/yapapi/rest/market.py
+++ b/yapapi/rest/market.py
@@ -9,7 +9,7 @@ from typing_extensions import Awaitable, AsyncContextManager
 
 from ya_market import ApiClient, ApiException, RequestorApi, models  # type: ignore
 
-from .common import SuppressedExceptions, is_recoverable_exception
+from .common import is_intermittent_error, SuppressedExceptions
 from ..props import Model
 
 
@@ -196,7 +196,7 @@ class Subscription(object):
 
             proposals = []
             try:
-                async with SuppressedExceptions(is_recoverable_exception):
+                async with SuppressedExceptions(is_intermittent_error):
                     proposals = await self._api.collect_offers(self._id, timeout=5, max_events=10)
             except ApiException as ex:
                 if ex.status == 404:


### PR DESCRIPTION
Changes in this PR:

- Make the `Executor` retry some operations that raise errors that indicate timeouts in API calls:
  - `Invoice.accept()`
  - `DebitNote.accept()`
- Ignore timeout errors in operations that are executed periodically:
  - `collect_offers()`
  - `get_invoice_events()`
  - `get_debit_note_events()`
  
The "timeout errors" are HTTP errors 408 and 504, `asyncio.TimeoutError` (indicating client-side timeout) and intermittent errors `aiohttp.ClientDisconnectedError` and `aiohttp.ClientOSError(errno=32)` (Broken Pipe).

Should fix:
- https://github.com/golemfactory/yagna-triage/issues/96
- https://github.com/golemfactory/yagna-triage/issues/98
- https://github.com/golemfactory/yagna-triage/issues/99

Note: "should fix" is obviously an overstatement, this PR won't prevent timeout-related API errors, it merely repeats each failed API call few times, making an assumption that the more attempts we make the less likely is that they will all fail.
