### PR TITLE
Return batch results (as awaitable) to the worker function

### DIFF
--- a/examples/blender/blender-async-results.py
+++ b/examples/blender/blender-async-results.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+import asyncio
+from datetime import datetime, timedelta
+import pathlib
+import sys
+
+from yapapi import (
+    Executor,
+    NoPaymentAccountError,
+    Task,
+    __version__ as yapapi_version,
+    WorkContext,
+    windows_event_loop_fix,
+)
+from yapapi.log import enable_default_logger, log_summary, log_event_repr  # noqa
+from yapapi.package import vm
+from yapapi.rest.activity import BatchTimeoutError
+
+examples_dir = pathlib.Path(__file__).resolve().parent.parent
+sys.path.append(str(examples_dir))
+
+from utils import (
+    build_parser,
+    TEXT_COLOR_CYAN,
+    TEXT_COLOR_DEFAULT,
+    TEXT_COLOR_RED,
+    TEXT_COLOR_YELLOW,
+)
+
+
+async def main(subnet_tag, driver=None, network=None):
+    package = await vm.repo(
+        image_hash="9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae",
+        min_mem_gib=0.5,
+        min_storage_gib=2.0,
+    )
+
+    async def worker(ctx: WorkContext, tasks):
+        script_dir = pathlib.Path(__file__).resolve().parent
+        scene_path = str(script_dir / "cubes.blend")
+        ctx.send_file(scene_path, "/golem/resource/scene.blend")
+        async for task in tasks:
+            frame = task.data
+            crops = [{"outfilebasename": "out", "borders_x": [0.0, 1.0], "borders_y": [0.0, 1.0]}]
+            ctx.send_json(
+                "/golem/work/params.json",
+                {
+                    "scene_file": "/golem/resource/scene.blend",
+                    "resolution": (400, 300),
+                    "use_compositing": False,
+                    "crops": crops,
+                    "samples": 100,
+                    "frames": [frame],
+                    "output_format": "PNG",
+                    "RESOURCES_DIR": "/golem/resources",
+                    "WORK_DIR": "/golem/work",
+                    "OUTPUT_DIR": "/golem/output",
+                },
+            )
+            ctx.run("/golem/entrypoints/run-blender.sh")
+            output_file = f"output_{frame}.png"
+            ctx.download_file(f"/golem/output/out{frame:04d}.png", output_file)
+
+            future_results = yield ctx.commit(wait_for_results=False)
+            # equivalent to:
+            #    future_results = yield ctx.commit_async()
+            # print("[Worker]: got future_results: ", future_results)
+            print("Maybe doing some work before looking at the results...")
+            await asyncio.sleep(1)
+            results = await future_results
+            print(f"Got results for {len(results)} commands")
+            task.accept_result(result=output_file)
+
+    # Iterator over the frame indices that we want to render
+    frames: range = range(0, 60, 10)
+    # Worst-case overhead, in minutes, for initialization (negotiation, file transfer etc.)
+    # TODO: make this dynamic, e.g. depending on the size of files to transfer
+    init_overhead = 3
+    # Providers will not accept work if the timeout is outside of the [5 min, 30min] range.
+    # We increase the lower bound to 6 min to account for the time needed for our demand to
+    # reach the providers.
+    min_timeout, max_timeout = 6, 30
+
+    timeout = timedelta(minutes=max(min(init_overhead + len(frames) * 2, max_timeout), min_timeout))
+
+    # By passing `event_consumer=log_summary()` we enable summary logging.
+    # See the documentation of the `yapapi.log` module on how to set
+    # the level of detail and format of the logged information.
+    async with Executor(
+        package=package,
+        max_workers=3,
+        budget=10.0,
+        timeout=timeout,
+        subnet_tag=subnet_tag,
+        driver=driver,
+        network=network,
+        event_consumer=log_summary(log_event_repr),
+    ) as executor:
+
+        print(
+            f"yapapi version: {TEXT_COLOR_YELLOW}{yapapi_version}{TEXT_COLOR_DEFAULT}\n"
+            f"Using subnet: {TEXT_COLOR_YELLOW}{subnet_tag}{TEXT_COLOR_DEFAULT}, "
+            f"payment driver: {TEXT_COLOR_YELLOW}{executor.driver}{TEXT_COLOR_DEFAULT}, "
+            f"and network: {TEXT_COLOR_YELLOW}{executor.network}{TEXT_COLOR_DEFAULT}\n"
+        )
+
+        num_tasks = 0
+        start_time = datetime.now()
+
+        async for task in executor.submit(worker, [Task(data=frame) for frame in frames]):
+            num_tasks += 1
+            print(
+                f"{TEXT_COLOR_CYAN}"
+                f"Task computed: {task}, result: {task.result}, time: {task.running_time}"
+                f"{TEXT_COLOR_DEFAULT}"
+            )
+
+        print(
+            f"{TEXT_COLOR_CYAN}"
+            f"{num_tasks} tasks computed, total time: {datetime.now() - start_time}"
+            f"{TEXT_COLOR_DEFAULT}"
+        )
+
+
+if __name__ == "__main__":
+    parser = build_parser("Render a Blender scene")
+    now = datetime.now().strftime("%Y-%m-%d_%H.%M.%S")
+    parser.set_defaults(log_file=f"blender-yapapi-{now}.log")
+    args = parser.parse_args()
+
+    # This is only required when running on Windows with Python prior to 3.8:
+    windows_event_loop_fix()
+
+    enable_default_logger(
+        log_file=args.log_file,
+        debug_activity_api=True,
+        debug_market_api=True,
+        debug_payment_api=True,
+    )
+
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(
+        main(subnet_tag=args.subnet_tag, driver=args.driver, network=args.network)
+    )
+
+    try:
+        loop.run_until_complete(task)
+    except NoPaymentAccountError as e:
+        handbook_url = (
+            "https://handbook.golem.network/requestor-tutorials/"
+            "flash-tutorial-of-requestor-development"
+        )
+        print(
+            f"{TEXT_COLOR_RED}"
+            f"No payment account initialized for driver `{e.required_driver}` "
+            f"and network `{e.required_network}`.\n\n"
+            f"See {handbook_url} on how to initialize payment accounts for a requestor node."
+            f"{TEXT_COLOR_DEFAULT}"
+        )
+    except KeyboardInterrupt:
+        print(
+            f"{TEXT_COLOR_YELLOW}"
+            "Shutting down gracefully, please wait a short while "
+            "or press Ctrl+C to exit immediately..."
+            f"{TEXT_COLOR_DEFAULT}"
+        )
+        task.cancel()
+        try:
+            loop.run_until_complete(task)
+            print(
+                f"{TEXT_COLOR_YELLOW}Shutdown completed, thank you for waiting!{TEXT_COLOR_DEFAULT}"
+            )
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            pass

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -375,7 +375,10 @@ class Executor(AsyncContextManager):
 
     async def _submit(
         self,
-        worker: Callable[[WorkContext, AsyncIterator[Task[D, R]]], AsyncGenerator[Work, None]],
+        worker: Callable[
+            [WorkContext, AsyncIterator[Task[D, R]]],
+            AsyncGenerator[Work, asyncio.Task]
+        ],
         data: Iterable[Task[D, R]],
         services: Set[asyncio.Task],
         workers: Set[asyncio.Task],
@@ -539,7 +542,13 @@ class Executor(AsyncContextManager):
                         work_context,
                         (Task.for_handle(handle, work_queue, emit) async for handle in consumer),
                     )
-                    async for batch in command_generator:
+
+                    try:
+                        batch: Optional[Work] = await command_generator.__anext__()
+                    except StopAsyncIteration:
+                        batch = None
+
+                    while batch:
                         batch_deadline = (
                             datetime.now(timezone.utc) + batch.timeout if batch.timeout else None
                         )
@@ -557,22 +566,66 @@ class Executor(AsyncContextManager):
                             await batch.prepare()
                             cc = CommandContainer()
                             batch.register(cc)
+
+                            import colors
+
+                            print(colors.yellow("[executor] Batch:"), cc.commands())
+
                             remote = await act.send(
                                 cc.commands(), stream_output, deadline=batch_deadline
                             )
                             cmds = cc.commands()
                             emit(events.ScriptSent(agr_id=agreement.id, task_id=task_id, cmds=cmds))
 
-                            async for evt_ctx in remote:
-                                evt = evt_ctx.event(agr_id=agreement.id, task_id=task_id, cmds=cmds)
-                                emit(evt)
-                                if isinstance(evt, events.CommandExecuted) and not evt.success:
-                                    raise CommandExecutionError(evt.command, evt.message)
+                            async def get_batch_results():
 
-                            emit(events.GettingResults(agr_id=agreement.id, task_id=task_id))
-                            await batch.post()
-                            emit(events.ScriptFinished(agr_id=agreement.id, task_id=task_id))
-                            await accept_payment_for_agreement(agreement.id, partial=True)
+                                print(colors.yellow("[get_batch_results] Waiting for results..."))
+
+                                results = []
+                                async for evt_ctx in remote:
+                                    evt = evt_ctx.event(
+                                        agr_id=agreement.id, task_id=task_id, cmds=cmds
+                                    )
+                                    emit(evt)
+                                    results.append(evt)
+                                    if isinstance(evt, events.CommandExecuted) and not evt.success:
+                                        raise CommandExecutionError(evt.command, evt.message)
+
+                                emit(events.GettingResults(agr_id=agreement.id, task_id=task_id))
+                                await batch.post()
+                                emit(events.ScriptFinished(agr_id=agreement.id, task_id=task_id))
+                                await accept_payment_for_agreement(agreement.id, partial=True)
+
+                                print(colors.yellow("[get_batch_results] Got results"))
+                                return results
+
+                            if batch.wait_for_results or batch.contains_init_step:
+                                # Block until the results are available
+                                print(
+                                    colors.yellow(
+                                        "[executor] Blocking until results are available..."
+                                    )
+                                )
+                                results = await get_batch_results()
+                                print(colors.yellow("[executor] Returning results"))
+
+                                async def make_awaitable():
+                                    return results
+
+                                batch = await command_generator.asend(make_awaitable())
+                            else:
+                                # Schedule the coroutine in a separate asyncio task
+                                print(colors.yellow("[executor] Scheduling getting the results..."))
+                                loop = asyncio.get_event_loop()
+                                results_task = loop.create_task(get_batch_results())
+                                print(colors.yellow("[executor] Returning results task"))
+                                batch = await command_generator.asend(results_task)
+
+                            print(colors.yellow("[executor] After asend()"))
+
+                        except StopAsyncIteration:
+                            print(colors.yellow("[executor] Got StopAsyncIteration"))
+                            break
 
                         except Exception:
 

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -12,6 +12,7 @@ import sys
 from typing import (
     AsyncContextManager,
     AsyncIterator,
+    Awaitable,
     Callable,
     Dict,
     Iterable,
@@ -193,7 +194,10 @@ class Executor(AsyncContextManager):
 
     async def submit(
         self,
-        worker: Callable[[WorkContext, AsyncIterator[Task[D, R]]], AsyncGenerator[Work, None]],
+        worker: Callable[
+            [WorkContext, AsyncIterator[Task[D, R]]],
+            AsyncGenerator[Work, Awaitable[List[events.CommandEvent]]],
+        ],
         data: Iterable[Task[D, R]],
     ) -> AsyncIterator[Task[D, R]]:
         """Submit a computation to be executed on providers.
@@ -377,7 +381,7 @@ class Executor(AsyncContextManager):
         self,
         worker: Callable[
             [WorkContext, AsyncIterator[Task[D, R]]],
-            AsyncGenerator[Work, asyncio.Task]
+            AsyncGenerator[Work, Awaitable[List[events.CommandEvent]]],
         ],
         data: Iterable[Task[D, R]],
         services: Set[asyncio.Task],
@@ -514,6 +518,9 @@ class Executor(AsyncContextManager):
         storage_manager = await self._stack.enter_async_context(gftp.provider())
 
         async def start_worker(agreement: rest.market.Agreement, node_info: NodeInfo) -> None:
+            def log(msg):
+                logger.info("\033[33m%s\033[m", msg)
+
             nonlocal last_wid
             wid = last_wid
             last_wid += 1
@@ -567,9 +574,7 @@ class Executor(AsyncContextManager):
                             cc = CommandContainer()
                             batch.register(cc)
 
-                            import colors
-
-                            print(colors.yellow("[executor] Batch:"), cc.commands())
+                            log(f"Batch: {len(cc.commands())} commands")
 
                             remote = await act.send(
                                 cc.commands(), stream_output, deadline=batch_deadline
@@ -577,9 +582,9 @@ class Executor(AsyncContextManager):
                             cmds = cc.commands()
                             emit(events.ScriptSent(agr_id=agreement.id, task_id=task_id, cmds=cmds))
 
-                            async def get_batch_results():
+                            async def get_batch_results() -> List[events.CommandEvent]:
 
-                                print(colors.yellow("[get_batch_results] Waiting for results..."))
+                                log("[get_batch_results] Waiting for results...")
 
                                 results = []
                                 async for evt_ctx in remote:
@@ -592,39 +597,33 @@ class Executor(AsyncContextManager):
                                         raise CommandExecutionError(evt.command, evt.message)
 
                                 emit(events.GettingResults(agr_id=agreement.id, task_id=task_id))
+                                assert batch
                                 await batch.post()
                                 emit(events.ScriptFinished(agr_id=agreement.id, task_id=task_id))
                                 await accept_payment_for_agreement(agreement.id, partial=True)
 
-                                print(colors.yellow("[get_batch_results] Got results"))
+                                log("[get_batch_results] Got results")
                                 return results
 
+                            loop = asyncio.get_event_loop()
                             if batch.wait_for_results or batch.contains_init_step:
                                 # Block until the results are available
-                                print(
-                                    colors.yellow(
-                                        "[executor] Blocking until results are available..."
-                                    )
-                                )
+                                log("Blocking until batch results are available...")
                                 results = await get_batch_results()
-                                print(colors.yellow("[executor] Returning results"))
-
-                                async def make_awaitable():
-                                    return results
-
-                                batch = await command_generator.asend(make_awaitable())
+                                log("Returning batch results")
+                                future_results = loop.create_future()
+                                future_results.set_result(results)
+                                batch = await command_generator.asend(future_results)
                             else:
                                 # Schedule the coroutine in a separate asyncio task
-                                print(colors.yellow("[executor] Scheduling getting the results..."))
-                                loop = asyncio.get_event_loop()
+                                log("Scheduling getting batch results...")
                                 results_task = loop.create_task(get_batch_results())
-                                print(colors.yellow("[executor] Returning results task"))
+                                log("Returning results task")
                                 batch = await command_generator.asend(results_task)
 
-                            print(colors.yellow("[executor] After asend()"))
+                            log("Awaitable sent to worker")
 
                         except StopAsyncIteration:
-                            print(colors.yellow("[executor] Got StopAsyncIteration"))
                             break
 
                         except Exception:

--- a/yapapi/executor/ctx.py
+++ b/yapapi/executor/ctx.py
@@ -50,6 +50,16 @@ class Work(abc.ABC):
         """Return the optional timeout set for execution of this work."""
         return None
 
+    @property
+    def wait_for_results(self) -> bool:
+        """Return `True` iff yielding this work item should block until the results are returned."""
+        return True
+
+    @property
+    def contains_init_step(self) -> bool:
+        """Return `True` iff this work item contains the initialization step."""
+        return False
+
 
 class _InitStep(Work):
     def register(self, commands: CommandContainer):
@@ -227,14 +237,34 @@ class _ReceiveJson(_ReceiveBytes):
 
 
 class Steps(Work):
-    def __init__(self, *steps: Work, timeout: Optional[timedelta] = None):
+    def __init__(
+        self, *steps: Work, timeout: Optional[timedelta] = None, wait_for_results: bool = True
+    ):
+        """Create a `Work` item consisting of a sequence of steps (subitems).
+
+        :param steps: sequence of steps to be executed
+        :param timeout: timeout for waiting for the steps' results
+        :param wait_for_results: whether yielding this work item should block
+            until the results are available
+        """
         self._steps: Tuple[Work, ...] = steps
         self._timeout: Optional[timedelta] = timeout
+        self._wait_for_results = wait_for_results
 
     @property
     def timeout(self) -> Optional[timedelta]:
         """Return the optional timeout set for execution of all steps."""
         return self._timeout
+
+    @property
+    def wait_for_results(self) -> bool:
+        """Return `True` iff yielding these steps should block until the results are available."""
+        return self._wait_for_results
+
+    @property
+    def contains_init_step(self) -> bool:
+        """Return `True` iff the steps include an initialization step."""
+        return any(isinstance(step, _InitStep) for step in self._steps)
 
     async def prepare(self):
         """Execute the `prepare` hook for all the defined steps."""
@@ -378,7 +408,7 @@ class WorkContext:
             _ReceiveJson(self._storage, src_path, on_download, limit, self._emitter)
         )
 
-    def commit(self, timeout: Optional[timedelta] = None) -> Work:
+    def commit(self, timeout: Optional[timedelta] = None, wait_for_results: bool = True) -> Work:
         """Creates a sequence of commands to be sent to provider.
 
         :return: Work object containing the sequence of commands
@@ -386,7 +416,10 @@ class WorkContext:
         """
         steps = self._pending_steps
         self._pending_steps = []
-        return Steps(*steps, timeout=timeout)
+        return Steps(*steps, timeout=timeout, wait_for_results=wait_for_results)
+
+    def commit_async(self) -> Work:
+        return self.commit(wait_for_results=False)
 
 
 class CaptureMode(enum.Enum):


### PR DESCRIPTION
Snippet from a modified `blender` example (https://github.com/golemfactory/yapapi/pull/366/files#diff-8181a3cb89d4ebc32f70360978ba0a86112b9249a500a7528854aaf071536563):
```python
            future_results = yield ctx.commit(wait_for_results=False)
            # equivalent to:
            #    future_results = yield ctx.commit_async()
            print("Maybe doing some work before looking at the results...")
            await asyncio.sleep(1)
            results = await future_results
            print(f"Got results for {len(results)} commands")
            task.accept_result(result=output_file)
```