### PR TITLE
Fix passing command errors from the engine to worker functions

### DIFF
--- a/yapapi/executor/_smartq.py
+++ b/yapapi/executor/_smartq.py
@@ -126,7 +126,13 @@ class SmartQueue(Generic[Item]):
         A queue has unassigned items iff the next call to `get()` will immediately return
         some item, without waiting for an item that is currently "in progress" to be rescheduled.
         """
-        return await self.has_new_items() or bool(self._rescheduled_items)
+        while True:
+            if self._rescheduled_items:
+                return True
+            try:
+                return await asyncio.wait_for(self.has_new_items(), 1.0)
+            except asyncio.TimeoutError:
+                pass
 
     def new_consumer(self) -> "Consumer[Item]":
         return Consumer(self)


### PR DESCRIPTION
Resolves #393 

Contains fixes for two separate issues reported by A&C Team:
- Fixes handling errors in the worker coroutine (#393, commit 03c5f55b28a8a78fafd88616a294289edd4b1759)
- Prevents blocking indefinitely while waiting for new taks if rescheduled tasks appear in `SmartQueue` (commit 9cbee0f1e473cb14d6e85701e09bc0293cdffe16).
