### PR TITLE
+ `WorkContext.terminate()`

### DIFF
--- a/tests/executor/test_ctx.py
+++ b/tests/executor/test_ctx.py
@@ -126,3 +126,13 @@ class TestWorkContext:
         await steps.post()
         self._assert_src_path(steps, src_path)
         assert self._on_download_executed
+
+    def test_terminate(self):
+        ctx = self._get_work_context(None)
+        ctx.terminate()
+        steps = ctx.commit()
+
+        c = CommandContainer()
+        steps.register(c)
+
+        assert c.commands() == [{'terminate': {}}]

--- a/tests/executor/test_ctx.py
+++ b/tests/executor/test_ctx.py
@@ -135,4 +135,4 @@ class TestWorkContext:
         c = CommandContainer()
         steps.register(c)
 
-        assert c.commands() == [{'terminate': {}}]
+        assert c.commands() == [{"terminate": {}}]

--- a/yapapi/executor/ctx.py
+++ b/yapapi/executor/ctx.py
@@ -61,6 +61,11 @@ class _Start(Work):
         commands.start()
 
 
+class _Terminate(Work):
+    def register(self, commands: CommandContainer):
+        commands.terminate()
+
+
 class _SendWork(Work, abc.ABC):
     def __init__(self, storage: StorageProvider, dst_path: str):
         self._storage = storage
@@ -306,12 +311,18 @@ class WorkContext:
         pass
 
     def deploy(self):
+        """Schedule a Deploy command."""
         self._implicit_init = False
         self._pending_steps.append(_Deploy())
 
     def start(self):
+        """Schedule a Start command."""
         self._implicit_init = False
         self._pending_steps.append(_Start())
+
+    def terminate(self):
+        """Schedule a Terminate command."""
+        self._pending_steps.append(_Terminate())
 
     def send_json(self, json_path: str, data: dict):
         """Schedule sending JSON data to the provider.

--- a/yapapi/executor/services.py
+++ b/yapapi/executor/services.py
@@ -146,7 +146,8 @@ class Service:
             yield
 
     async def shutdown(self):
-        yield
+        self._ctx.terminate()
+        yield self._ctx.commit()
 
     @property
     def is_available(self):


### PR DESCRIPTION
+ `ctx.terminate()` as a default operation in the default `Service.shutdown` handler

closes #391 