### PR TITLE
Move Golem and Job from yapapi.executor.__init__ to yapapi.golem

### DIFF
--- a/tests/executor/test_payment_platforms.py
+++ b/tests/executor/test_payment_platforms.py
@@ -5,7 +5,9 @@ import pytest
 
 from ya_payment import RequestorApi
 
-from yapapi.executor import Executor, NoPaymentAccountError, DEFAULT_NETWORK, DEFAULT_DRIVER
+from yapapi import NoPaymentAccountError
+from yapapi.engine import DEFAULT_NETWORK, DEFAULT_DRIVER
+from yapapi.executor import Executor
 from yapapi.rest.payment import Account, Payment
 
 

--- a/tests/executor/test_strategy.py
+++ b/tests/executor/test_strategy.py
@@ -3,7 +3,7 @@ from itertools import product
 import pytest
 from unittest.mock import Mock
 
-from yapapi.executor import Golem
+from yapapi import Golem
 from yapapi.executor.strategy import (
     DecreaseScoreForUnconfirmedAgreement,
     LeastExpensiveLinearPayuMS,

--- a/yapapi/__init__.py
+++ b/yapapi/__init__.py
@@ -10,13 +10,11 @@ from .executor import (
     CaptureContext,
     ExecOptions,
     Executor,
-    Engine,
-    Job,
     Task,
     WorkContext,
 )
 
-from yapapi.engine import NoPaymentAccountError
+from yapapi.engine import NoPaymentAccountError, WorkItem
 from yapapi.golem import Golem
 
 
@@ -60,6 +58,8 @@ __all__ = [
     "Task",
     "WorkContext",
     "CaptureContext",
-    "Engine",
-    "Job",
+    "ExecOptions",
+    "Golem",
+    "NoPaymentAccountError",
+    "WorkItem",
 ]

--- a/yapapi/__init__.py
+++ b/yapapi/__init__.py
@@ -10,12 +10,14 @@ from .executor import (
     CaptureContext,
     ExecOptions,
     Executor,
-    Golem,
+    Engine,
     Job,
-    NoPaymentAccountError,
     Task,
     WorkContext,
 )
+
+from yapapi.engine import NoPaymentAccountError
+from yapapi.golem import Golem
 
 
 def get_version() -> str:
@@ -58,6 +60,6 @@ __all__ = [
     "Task",
     "WorkContext",
     "CaptureContext",
-    "Golem",
+    "Engine",
     "Job",
 ]

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -103,7 +103,7 @@ exescript_ids: Iterator[int] = itertools.count(1)
 """An iterator providing unique ids used to correlate events related to a single exe script."""
 
 
-class Engine(AsyncContextManager):
+class _Engine(AsyncContextManager):
     """Base execution engine containing functions common to all modes of operation."""
 
     def __init__(
@@ -216,7 +216,7 @@ class Engine(AsyncContextManager):
         if self._wrapped_consumer:
             self._wrapped_consumer.async_call(event)
 
-    async def __aenter__(self) -> "Engine":
+    async def __aenter__(self) -> "_Engine":
         """Initialize resources and start background services used by this engine."""
 
         try:
@@ -241,7 +241,7 @@ class Engine(AsyncContextManager):
             payment_client = await stack.enter_async_context(self._api_config.payment())
             self._payment_api = rest.Payment(payment_client)
 
-            self.payment_decorator = Engine.PaymentDecorator(await self._create_allocations())
+            self.payment_decorator = _Engine.PaymentDecorator(await self._create_allocations())
 
             # TODO: make the method starting the process_invoices() task an async context manager
             # to simplify code in __aexit__()
@@ -561,7 +561,7 @@ class Job:
 
     def __init__(
         self,
-        engine: Engine,
+        engine: _Engine,
         expiration_time: datetime,
         payload: Payload,
     ):

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -1,0 +1,731 @@
+import asyncio
+from asyncio import CancelledError
+import contextlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+import itertools
+import logging
+import sys
+from typing import (
+    AsyncContextManager,
+    Awaitable,
+    Callable,
+    cast,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+from typing_extensions import Final, AsyncGenerator
+import uuid
+
+if sys.version_info >= (3, 7):
+    from contextlib import AsyncExitStack
+else:
+    from async_exit_stack import AsyncExitStack  # type: ignore
+
+
+from yapapi import rest
+from yapapi.executor import AgreementsPool, events
+from yapapi.executor.ctx import CommandContainer, ExecOptions, Work
+from yapapi.executor.strategy import (
+    DecreaseScoreForUnconfirmedAgreement,
+    LeastExpensiveLinearPayuMS,
+    MarketStrategy,
+    SCORE_NEUTRAL,
+)
+from yapapi.executor.utils import AsyncWrapper
+from yapapi.payload import Payload
+from yapapi.props import com, Activity, NodeInfo, NodeInfoKeys
+from yapapi.props.builder import DemandBuilder, DemandDecorator
+from yapapi.rest.activity import CommandExecutionError
+from yapapi.rest.market import OfferProposal, Subscription
+from yapapi.storage import gftp
+
+
+DEBIT_NOTE_MIN_TIMEOUT: Final[int] = 30  # in seconds
+"Shortest debit note acceptance timeout the requestor will accept."
+
+DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP: Final[str] = "golem.com.payment.debit-notes.accept-timeout?"
+
+DEFAULT_DRIVER = "zksync"
+DEFAULT_NETWORK = "rinkeby"
+
+
+logger = logging.getLogger("yapapi.executor")
+
+
+class NoPaymentAccountError(Exception):
+    """The error raised if no payment account for the required driver/network is available."""
+
+    required_driver: str
+    """Payment driver required for the account."""
+
+    required_network: str
+    """Network required for the account."""
+
+    def __init__(self, required_driver: str, required_network: str):
+        """Initialize `NoPaymentAccountError`.
+
+        :param required_driver: payment driver for which initialization was required
+        :param required_network: payment network for which initialization was required
+        """
+        self.required_driver: str = required_driver
+        self.required_network: str = required_network
+
+    def __str__(self) -> str:
+        return (
+            f"No payment account available for driver `{self.required_driver}`"
+            f" and network `{self.required_network}`"
+        )
+
+
+WorkItem = Union[Work, Tuple[Work, ExecOptions]]
+"""The type of items yielded by a generator created by the `worker` function supplied by user."""
+
+
+def _unpack_work_item(item: WorkItem) -> Tuple[Work, ExecOptions]:
+    """Extract `Work` object and options from a work item.
+
+    If the item does not specify options, default ones are provided.
+    """
+    if isinstance(item, tuple):
+        return item
+    else:
+        return item, ExecOptions()
+
+
+exescript_ids: Iterator[int] = itertools.count(1)
+"""An iterator providing unique ids used to correlate events related to a single exe script."""
+
+
+class Engine(AsyncContextManager):
+    """Base execution engine containing functions common to all modes of operation."""
+
+    def __init__(
+        self,
+        *,
+        budget: Union[float, Decimal],
+        strategy: Optional[MarketStrategy] = None,
+        subnet_tag: Optional[str] = None,
+        driver: Optional[str] = None,
+        network: Optional[str] = None,
+        event_consumer: Optional[Callable[[events.Event], None]] = None,
+        stream_output: bool = False,
+        app_key: Optional[str] = None,
+    ):
+        """Initialize the engine.
+
+        :param budget: maximum budget for payments
+        :param strategy: market strategy used to select providers from the market
+            (e.g. LeastExpensiveLinearPayuMS or DummyMS)
+        :param subnet_tag: use only providers in the subnet with the subnet_tag name
+        :param driver: name of the payment driver to use or `None` to use the default driver;
+            only payment platforms with the specified driver will be used
+        :param network: name of the network to use or `None` to use the default network;
+            only payment platforms with the specified network will be used
+        :param event_consumer: a callable that processes events related to the
+            computation; by default it is a function that logs all events
+        :param stream_output: stream computation output from providers
+        :param app_key: optional Yagna application key. If not provided, the default is to
+                        get the value from `YAGNA_APPKEY` environment variable
+        """
+        self._api_config = rest.Configuration(app_key)
+        self._budget_amount = Decimal(budget)
+        self._budget_allocations: List[rest.payment.Allocation] = []
+
+        if not strategy:
+            strategy = LeastExpensiveLinearPayuMS(
+                max_fixed_price=Decimal("1.0"),
+                max_price_for={com.Counter.CPU: Decimal("0.2"), com.Counter.TIME: Decimal("0.1")},
+            )
+            # The factor 0.5 below means that an offer for a provider that failed to confirm
+            # the last agreement proposed to them will have it's score multiplied by 0.5.
+            strategy = DecreaseScoreForUnconfirmedAgreement(strategy, 0.5)
+        self._strategy = strategy
+
+        self._subnet: Optional[str] = subnet_tag
+        self._driver = driver.lower() if driver else DEFAULT_DRIVER
+        self._network = network.lower() if network else DEFAULT_NETWORK
+
+        if not event_consumer:
+            # Use local import to avoid cyclic imports when yapapi.log
+            # is imported by client code
+            from yapapi.log import log_event_repr
+
+            event_consumer = log_event_repr
+
+        # Add buffering to the provided event emitter to make sure
+        # that emitting events will not block
+        self._wrapped_consumer = AsyncWrapper(event_consumer)
+
+        self._stream_output = stream_output
+
+        # initialize the payment structures
+        self._agreements_to_pay: Set[str] = set()
+        self._agreements_accepting_debit_notes: Set[str] = set()
+        self._invoices: Dict[str, rest.payment.Invoice] = dict()
+        self._payment_closing: bool = False
+
+        # a set of `Job` instances used to track jobs - computations or services - started
+        # it can be used to wait until all jobs are finished
+        self._jobs: Set[Job] = set()
+        self._process_invoices_job: Optional[asyncio.Task] = None
+
+        self._services: Set[asyncio.Task] = set()
+        self._stack = AsyncExitStack()
+
+    async def create_demand_builder(
+        self, expiration_time: datetime, payload: Payload
+    ) -> DemandBuilder:
+        """Create a `DemandBuilder` for given `payload` and `expiration_time`."""
+        builder = DemandBuilder()
+        builder.add(Activity(expiration=expiration_time, multi_activity=True))
+        builder.add(NodeInfo(subnet_tag=self._subnet))
+        if self._subnet:
+            builder.ensure(f"({NodeInfoKeys.subnet_tag}={self._subnet})")
+        await builder.decorate(self.payment_decorator, self.strategy, payload)
+        return builder
+
+    @property
+    def driver(self) -> str:
+        """Return the name of the payment driver used by this engine."""
+        return self._driver
+
+    @property
+    def network(self) -> str:
+        """Return the name of the payment network used by this engine."""
+        return self._network
+
+    @property
+    def storage_manager(self):
+        """Return the storage manager used by this engine."""
+        return self._storage_manager
+
+    @property
+    def strategy(self) -> MarketStrategy:
+        """Return the instance of `MarketStrategy` used by this engine."""
+        return self._strategy
+
+    def emit(self, event: events.Event) -> None:
+        """Emit an event to be consumed by this engine's event consumer."""
+        if self._wrapped_consumer:
+            self._wrapped_consumer.async_call(event)
+
+    async def __aenter__(self) -> "Engine":
+        """Initialize resources and start background services used by this engine."""
+
+        try:
+            stack = self._stack
+
+            await stack.enter_async_context(self._wrapped_consumer)
+
+            def report_shutdown(*exc_info):
+                if any(item for item in exc_info):
+                    self.emit(events.ShutdownFinished(exc_info=exc_info))  # noqa
+                else:
+                    self.emit(events.ShutdownFinished())
+
+            stack.push(report_shutdown)
+
+            market_client = await stack.enter_async_context(self._api_config.market())
+            self._market_api = rest.Market(market_client)
+
+            activity_client = await stack.enter_async_context(self._api_config.activity())
+            self._activity_api = rest.Activity(activity_client)
+
+            payment_client = await stack.enter_async_context(self._api_config.payment())
+            self._payment_api = rest.Payment(payment_client)
+
+            self.payment_decorator = Engine.PaymentDecorator(await self._create_allocations())
+
+            # TODO: make the method starting the process_invoices() task an async context manager
+            # to simplify code in __aexit__()
+            loop = asyncio.get_event_loop()
+            self._process_invoices_job = loop.create_task(self._process_invoices())
+            self._services.add(self._process_invoices_job)
+            self._services.add(loop.create_task(self._process_debit_notes()))
+
+            self._storage_manager = await stack.enter_async_context(gftp.provider())
+
+            stack.push_async_exit(self._shutdown)
+
+            return self
+        except:
+            await self.__aexit__(*sys.exc_info())
+            raise
+
+    async def _shutdown(self, *exc_info):
+        """Shutdown this Golem instance."""
+
+        # Importing this at the beginning would cause circular dependencies
+        from yapapi.log import pluralize
+
+        logger.info("Golem is shutting down...")
+        # Wait until all computations are finished
+        await asyncio.gather(*[job.finished.wait() for job in self._jobs])
+        logger.info("All jobs have finished")
+
+        self._payment_closing = True
+
+        for task in self._services:
+            if task is not self._process_invoices_job:
+                task.cancel()
+
+        if self._process_invoices_job and not any(
+            True for job in self._jobs if job.agreements_pool.confirmed > 0
+        ):
+            logger.debug("No need to wait for invoices.")
+            self._process_invoices_job.cancel()
+
+        try:
+            logger.info("Waiting for Golem services to finish...")
+            _, pending = await asyncio.wait(
+                self._services, timeout=10, return_when=asyncio.ALL_COMPLETED
+            )
+            if pending:
+                logger.debug("%s still running: %s", pluralize(len(pending), "service"), pending)
+        except Exception:
+            logger.debug("Got error when waiting for services to finish", exc_info=True)
+
+        if self._agreements_to_pay and self._process_invoices_job:
+            logger.info(
+                "%s still unpaid, waiting for invoices...",
+                pluralize(len(self._agreements_to_pay), "agreement"),
+            )
+            try:
+                await asyncio.wait_for(self._process_invoices_job, timeout=30)
+            except asyncio.TimeoutError:
+                logger.debug("process_invoices_job cancelled")
+            if self._agreements_to_pay:
+                logger.warning("Unpaid agreements: %s", self._agreements_to_pay)
+
+        await asyncio.gather(*[job.finished.wait() for job in self._jobs])
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self._stack.aclose()
+
+    async def _create_allocations(self) -> rest.payment.MarketDecoration:
+
+        if not self._budget_allocations:
+            async for account in self._payment_api.accounts():
+                driver = account.driver.lower()
+                network = account.network.lower()
+                if (driver, network) != (self._driver, self._network):
+                    logger.debug(
+                        "Not using payment platform `%s`, platform's driver/network "
+                        "`%s`/`%s` is different than requested driver/network `%s`/`%s`",
+                        account.platform,
+                        driver,
+                        network,
+                        self._driver,
+                        self._network,
+                    )
+                    continue
+                logger.debug("Creating allocation using payment platform `%s`", account.platform)
+                allocation = cast(
+                    rest.payment.Allocation,
+                    await self._stack.enter_async_context(
+                        self._payment_api.new_allocation(
+                            self._budget_amount,
+                            payment_platform=account.platform,
+                            payment_address=account.address,
+                            #   TODO what do to with this?
+                            #   expires=self._expires + CFG_INVOICE_TIMEOUT,
+                        )
+                    ),
+                )
+                self._budget_allocations.append(allocation)
+
+            if not self._budget_allocations:
+                raise NoPaymentAccountError(self._driver, self._network)
+
+        allocation_ids = [allocation.id for allocation in self._budget_allocations]
+        return await self._payment_api.decorate_demand(allocation_ids)
+
+    def _get_allocation(
+        self, item: Union[rest.payment.DebitNote, rest.payment.Invoice]
+    ) -> rest.payment.Allocation:
+        try:
+            return next(
+                allocation
+                for allocation in self._budget_allocations
+                if allocation.payment_address == item.payer_addr
+                and allocation.payment_platform == item.payment_platform
+            )
+        except:
+            raise ValueError(f"No allocation for {item.payment_platform} {item.payer_addr}.")
+
+    async def _process_invoices(self) -> None:
+        """Process incoming invoices."""
+
+        async for invoice in self._payment_api.incoming_invoices():
+            if invoice.agreement_id in self._agreements_to_pay:
+                self.emit(
+                    events.InvoiceReceived(
+                        agr_id=invoice.agreement_id,
+                        inv_id=invoice.invoice_id,
+                        amount=invoice.amount,
+                    )
+                )
+                try:
+                    allocation = self._get_allocation(invoice)
+                    await invoice.accept(amount=invoice.amount, allocation=allocation)
+                except CancelledError:
+                    raise
+                except Exception:
+                    self.emit(
+                        events.PaymentFailed(
+                            agr_id=invoice.agreement_id, exc_info=sys.exc_info()  # type: ignore
+                        )
+                    )
+                else:
+                    self._agreements_to_pay.remove(invoice.agreement_id)
+                    assert invoice.agreement_id in self._agreements_accepting_debit_notes
+                    self._agreements_accepting_debit_notes.remove(invoice.agreement_id)
+                    self.emit(
+                        events.PaymentAccepted(
+                            agr_id=invoice.agreement_id,
+                            inv_id=invoice.invoice_id,
+                            amount=invoice.amount,
+                        )
+                    )
+            else:
+                self._invoices[invoice.agreement_id] = invoice
+            if self._payment_closing and not self._agreements_to_pay:
+                break
+
+    async def _process_debit_notes(self) -> None:
+        """Process incoming debit notes."""
+
+        async for debit_note in self._payment_api.incoming_debit_notes():
+            if debit_note.agreement_id in self._agreements_accepting_debit_notes:
+                self.emit(
+                    events.DebitNoteReceived(
+                        agr_id=debit_note.agreement_id,
+                        amount=debit_note.total_amount_due,
+                        note_id=debit_note.debit_note_id,
+                    )
+                )
+                try:
+                    allocation = self._get_allocation(debit_note)
+                    await debit_note.accept(
+                        amount=debit_note.total_amount_due, allocation=allocation
+                    )
+                except CancelledError:
+                    raise
+                except Exception:
+                    self.emit(
+                        events.PaymentFailed(
+                            agr_id=debit_note.agreement_id, exc_info=sys.exc_info()  # type: ignore
+                        )
+                    )
+            if self._payment_closing and not self._agreements_to_pay:
+                break
+
+    async def accept_payments_for_agreement(
+        self, agreement_id: str, *, partial: bool = False
+    ) -> None:
+        """Add given agreement to the set of agreements for which invoices should be accepted."""
+
+        self.emit(events.PaymentPrepared(agr_id=agreement_id))
+        inv = self._invoices.get(agreement_id)
+        if inv is None:
+            self._agreements_to_pay.add(agreement_id)
+            self.emit(events.PaymentQueued(agr_id=agreement_id))
+            return
+        del self._invoices[agreement_id]
+        allocation = self._get_allocation(inv)
+        await inv.accept(amount=inv.amount, allocation=allocation)
+        self.emit(
+            events.PaymentAccepted(agr_id=agreement_id, inv_id=inv.invoice_id, amount=inv.amount)
+        )
+
+    def accept_debit_notes_for_agreement(self, agreement_id: str) -> None:
+        """Add given agreement to the set of agreements for which debit notes should be accepted."""
+        self._agreements_accepting_debit_notes.add(agreement_id)
+
+    def add_job(self, job: "Job"):
+        """Register a job with this engine."""
+        self._jobs.add(job)
+
+    @staticmethod
+    def finalize_job(job: "Job"):
+        """Mark a job as finished."""
+        job.finished.set()
+
+    @dataclass
+    class PaymentDecorator(DemandDecorator):
+        """A `DemandDecorator` that adds payment-related constraints and properties to a Demand."""
+
+        market_decoration: rest.payment.MarketDecoration
+
+        async def decorate_demand(self, demand: DemandBuilder):
+            """Add properties and constraints to a Demand."""
+            for constraint in self.market_decoration.constraints:
+                demand.ensure(constraint)
+            demand.properties.update({p.key: p.value for p in self.market_decoration.properties})
+
+    async def create_activity(self, agreement_id: str):
+        """Create an activity for given `agreement_id`."""
+        return await self._activity_api.new_activity(
+            agreement_id, stream_events=self._stream_output
+        )
+
+    async def process_batches(
+        self,
+        agreement_id: str,
+        activity: rest.activity.Activity,
+        command_generator: AsyncGenerator[WorkItem, Awaitable[List[events.CommandEvent]]],
+    ) -> None:
+        """Send command batches produced by `command_generator` to `activity`."""
+
+        item = await command_generator.__anext__()
+
+        while True:
+
+            batch, exec_options = _unpack_work_item(item)
+
+            # TODO: `task_id` should really be `batch_id`, but then we should also rename
+            # `task_id` field of several events (e.g. `ScriptSent`)
+            script_id = str(next(exescript_ids))
+
+            if batch.timeout:
+                if exec_options.batch_timeout:
+                    logger.warning(
+                        "Overriding batch timeout set with commit(batch_timeout)"
+                        "by the value set in exec options"
+                    )
+                else:
+                    exec_options.batch_timeout = batch.timeout
+
+            batch_deadline = (
+                datetime.now(timezone.utc) + exec_options.batch_timeout
+                if exec_options.batch_timeout
+                else None
+            )
+
+            await batch.prepare()
+            cc = CommandContainer()
+            batch.register(cc)
+            remote = await activity.send(cc.commands(), deadline=batch_deadline)
+            cmds = cc.commands()
+            self.emit(events.ScriptSent(agr_id=agreement_id, script_id=script_id, cmds=cmds))
+
+            async def get_batch_results() -> List[events.CommandEvent]:
+                results = []
+                async for evt_ctx in remote:
+                    evt = evt_ctx.event(agr_id=agreement_id, script_id=script_id, cmds=cmds)
+                    self.emit(evt)
+                    results.append(evt)
+                    if isinstance(evt, events.CommandExecuted) and not evt.success:
+                        raise CommandExecutionError(evt.command, evt.message, evt.stderr)
+
+                self.emit(events.GettingResults(agr_id=agreement_id, script_id=script_id))
+                await batch.post()
+                self.emit(events.ScriptFinished(agr_id=agreement_id, script_id=script_id))
+                await self.accept_payments_for_agreement(agreement_id, partial=True)
+                return results
+
+            loop = asyncio.get_event_loop()
+
+            if exec_options.wait_for_results:
+                # Block until the results are available
+                try:
+                    future_results = loop.create_future()
+                    results = await get_batch_results()
+                    future_results.set_result(results)
+                except Exception:
+                    # Raise the exception in `command_generator` (the `worker` coroutine).
+                    # If the client code is able to handle it then we'll proceed with
+                    # subsequent batches. Otherwise the worker finishes with error.
+                    item = await command_generator.athrow(*sys.exc_info())
+                else:
+                    item = await command_generator.asend(future_results)
+
+            else:
+                # Schedule the coroutine in a separate asyncio task
+                future_results = loop.create_task(get_batch_results())
+                item = await command_generator.asend(future_results)
+
+
+class Job:
+    """Functionality related to a single job.
+
+    Responsible for posting a Demand to market and collecting Offer proposals for the Demand.
+    """
+
+    def __init__(
+        self,
+        engine: Engine,
+        expiration_time: datetime,
+        payload: Payload,
+    ):
+        """Initialize a `Job` instance.
+
+        param engine: a `Golem` engine which will run this job
+        param expiration_time: expiration time for the job; all agreements created for this job
+            must expire before this date
+        param payload: definition of a service runtime or a runtime package that needs to
+            be deployed on providers for executing this job
+        """
+
+        self.id = str(uuid.uuid4())
+        self.engine = engine
+        self.offers_collected: int = 0
+        self.proposals_confirmed: int = 0
+        self.expiration_time: datetime = expiration_time
+        self.payload: Payload = payload
+
+        self.agreements_pool = AgreementsPool(self.engine.emit)
+        self.finished = asyncio.Event()
+
+    async def _handle_proposal(
+        self,
+        proposal: OfferProposal,
+        demand_builder: DemandBuilder,
+    ) -> events.Event:
+        """Handle a single `OfferProposal`.
+
+        A `proposal` is scored and then can be rejected, responded with
+        a counter-proposal or stored in an agreements pool to be used
+        for negotiating an agreement.
+        """
+
+        async def reject_proposal(reason: str) -> events.ProposalRejected:
+            """Reject `proposal` due to given `reason`."""
+            await proposal.reject(reason)
+            return events.ProposalRejected(prop_id=proposal.id, reason=reason)
+
+        score = await self.engine._strategy.score_offer(proposal, self.agreements_pool)
+        logger.debug(
+            "Scored offer %s, provider: %s, strategy: %s, score: %f",
+            proposal.id,
+            proposal.props.get("golem.node.id.name"),
+            type(self.engine._strategy).__name__,
+            score,
+        )
+
+        if score < SCORE_NEUTRAL:
+            return await reject_proposal("Score too low")
+
+        if not proposal.is_draft:
+            # Proposal is not yet a draft of an agreement
+
+            # Check if any of the supported payment platforms matches the proposal
+            common_platforms = self._get_common_payment_platforms(proposal)
+            if common_platforms:
+                demand_builder.properties["golem.com.payment.chosen-platform"] = next(
+                    iter(common_platforms)
+                )
+            else:
+                # reject proposal if there are no common payment platforms
+                return await reject_proposal("No common payment platform")
+
+            # Check if the timeout for debit note acceptance is not too low
+            timeout = proposal.props.get(DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP)
+            if timeout:
+                if timeout < DEBIT_NOTE_MIN_TIMEOUT:
+                    return await reject_proposal("Debit note acceptance timeout is too short")
+                else:
+                    demand_builder.properties[DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP] = timeout
+
+            await proposal.respond(demand_builder.properties, demand_builder.constraints)
+            return events.ProposalResponded(prop_id=proposal.id)
+
+        else:
+            # It's a draft agreement
+            await self.agreements_pool.add_proposal(score, proposal)
+            return events.ProposalConfirmed(prop_id=proposal.id)
+
+    async def _find_offers_for_subscription(
+        self,
+        subscription: Subscription,
+        demand_builder: DemandBuilder,
+    ) -> None:
+        """Create a market subscription and repeatedly collect offer proposals for it.
+
+        Collected proposals are processed concurrently using a bounded number
+        of asyncio tasks.
+
+        :param state: A state related to a call to `Executor.submit()`
+        """
+        max_number_of_tasks = 5
+
+        try:
+            proposals = subscription.events()
+        except Exception as ex:
+            self.engine.emit(events.CollectFailed(sub_id=subscription.id, reason=str(ex)))
+            raise
+
+        # A semaphore is used to limit the number of handler tasks
+        semaphore = asyncio.Semaphore(max_number_of_tasks)
+
+        async for proposal in proposals:
+
+            self.engine.emit(
+                events.ProposalReceived(prop_id=proposal.id, provider_id=proposal.issuer)
+            )
+            self.offers_collected += 1
+
+            async def handler(proposal_):
+                """Wrap `_handle_proposal()` method with error handling."""
+                try:
+                    event = await self._handle_proposal(proposal_, demand_builder)
+                    assert isinstance(event, events.ProposalEvent)
+                    self.engine.emit(event)
+                    if isinstance(event, events.ProposalConfirmed):
+                        self.proposals_confirmed += 1
+                except CancelledError:
+                    raise
+                except Exception:
+                    with contextlib.suppress(Exception):
+                        self.engine.emit(
+                            events.ProposalFailed(
+                                prop_id=proposal_.id, exc_info=sys.exc_info()  # type: ignore
+                            )
+                        )
+                finally:
+                    semaphore.release()
+
+            # Create a new handler task
+            await semaphore.acquire()
+            asyncio.get_event_loop().create_task(handler(proposal))
+
+    async def find_offers(self) -> None:
+        """Create demand subscription and process offers.
+
+        When the subscription expires, create a new one. And so on...
+        """
+
+        builder = await self.engine.create_demand_builder(self.expiration_time, self.payload)
+
+        while True:
+            try:
+                subscription = await builder.subscribe(self.engine._market_api)
+                self.engine.emit(events.SubscriptionCreated(sub_id=subscription.id))
+            except Exception as ex:
+                self.engine.emit(events.SubscriptionFailed(reason=str(ex)))
+                raise
+            async with subscription:
+                await self._find_offers_for_subscription(subscription, builder)
+
+    # TODO: move to Golem
+    def _get_common_payment_platforms(self, proposal: rest.market.OfferProposal) -> Set[str]:
+        prov_platforms = {
+            property.split(".")[4]
+            for property in proposal.props
+            if property.startswith("golem.com.payment.platform.") and property is not None
+        }
+        if not prov_platforms:
+            prov_platforms = {"NGNT"}
+        req_platforms = {
+            allocation.payment_platform
+            for allocation in self.engine._budget_allocations
+            if allocation.payment_platform is not None
+        }
+        return req_platforms.intersection(prov_platforms)

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -15,7 +15,6 @@ from typing import (
     Optional,
     Set,
     TypeVar,
-    TYPE_CHECKING,
     Union,
     cast,
     overload,
@@ -29,7 +28,6 @@ from .ctx import CaptureContext, CommandContainer, ExecOptions, Work, WorkContex
 from .events import Event
 from . import events
 from .task import Task, TaskStatus
-from .utils import AsyncWrapper
 from ..payload import Payload
 from ..props import NodeInfo
 from .. import rest
@@ -61,7 +59,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_GET_OFFERS_TIMEOUT = timedelta(seconds=20)
 
 
-from yapapi.engine import Engine, Job, WorkItem
+from yapapi.engine import _Engine, Job, WorkItem
 from yapapi.executor.ctx import Work
 
 
@@ -83,7 +81,7 @@ class Executor(AsyncContextManager):
         payload: Optional[Payload] = None,
         max_workers: int = 5,
         timeout: timedelta = DEFAULT_EXECUTOR_TIMEOUT,
-        _engine: Engine,
+        _engine: _Engine,
     ):
         """Initialize the `Executor` to use a specific Golem `_engine`."""
 
@@ -135,7 +133,7 @@ class Executor(AsyncContextManager):
         timeout: timedelta = DEFAULT_EXECUTOR_TIMEOUT,
         package: Optional[Payload] = None,
         payload: Optional[Payload] = None,
-        _engine: Optional[Engine] = None,
+        _engine: Optional[_Engine] = None,
     ):
         """Initialize an `Executor`.
 
@@ -173,7 +171,7 @@ class Executor(AsyncContextManager):
             if not budget:
                 raise ValueError("Missing value for `budget` argument.")
 
-            self._engine = Engine(
+            self._engine = _Engine(
                 budget=budget,
                 strategy=strategy,
                 subnet_tag=subnet_tag,

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -1,37 +1,27 @@
 """An implementation of the new Golem's task executor."""
 import asyncio
 from asyncio import CancelledError
-import contextlib
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-import itertools
 import logging
 import sys
 from typing import (
-    Any,
     AsyncContextManager,
     AsyncIterator,
     Awaitable,
     Callable,
-    Dict,
     Iterable,
-    Iterator,
     List,
     Optional,
     Set,
-    Tuple,
-    Type,
     TypeVar,
     TYPE_CHECKING,
     Union,
     cast,
     overload,
 )
-import uuid
 import warnings
 
-
-from dataclasses import dataclass
 from yapapi.executor.agreements_pool import AgreementsPool
 from typing_extensions import Final, AsyncGenerator
 
@@ -41,16 +31,10 @@ from . import events
 from .task import Task, TaskStatus
 from .utils import AsyncWrapper
 from ..payload import Payload
-from ..props import Activity, com, NodeInfo, NodeInfoKeys
-from ..props.builder import DemandBuilder, DemandDecorator
+from ..props import NodeInfo
 from .. import rest
-from ..rest.activity import CommandExecutionError
-from ..rest.market import OfferProposal, Subscription
-from ..storage import gftp
 from ._smartq import SmartQueue
 
-if TYPE_CHECKING:
-    from yapapi.services import Cluster, Service
 from .strategy import (
     DecreaseScoreForUnconfirmedAgreement,
     LeastExpensiveLinearPayuMS,
@@ -63,10 +47,6 @@ if sys.version_info >= (3, 7):
 else:
     from async_exit_stack import AsyncExitStack  # type: ignore
 
-DEBIT_NOTE_MIN_TIMEOUT: Final[int] = 30  # in seconds
-"Shortest debit note acceptance timeout the requestor will accept."
-
-DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP: Final[str] = "golem.com.payment.debit-notes.accept-timeout?"
 
 CFG_INVOICE_TIMEOUT: Final[timedelta] = timedelta(minutes=5)
 "Time to receive invoice from provider after tasks ended."
@@ -74,768 +54,19 @@ CFG_INVOICE_TIMEOUT: Final[timedelta] = timedelta(minutes=5)
 DEFAULT_EXECUTOR_TIMEOUT: Final[timedelta] = timedelta(minutes=15)
 "Joint timeout for all tasks submitted to an executor."
 
-DEFAULT_DRIVER = "zksync"
-DEFAULT_NETWORK = "rinkeby"
 
 logger = logging.getLogger(__name__)
 
 
-class NoPaymentAccountError(Exception):
-    """The error raised if no payment account for the required driver/network is available."""
-
-    required_driver: str
-    """Payment driver required for the account."""
-
-    required_network: str
-    """Network required for the account."""
-
-    def __init__(self, required_driver: str, required_network: str):
-        """Initialize `NoPaymentAccountError`.
-
-        :param required_driver: payment driver for which initialization was required
-        :param required_network: payment network for which initialization was required
-        """
-        self.required_driver: str = required_driver
-        self.required_network: str = required_network
-
-    def __str__(self) -> str:
-        return (
-            f"No payment account available for driver `{self.required_driver}`"
-            f" and network `{self.required_network}`"
-        )
+DEFAULT_GET_OFFERS_TIMEOUT = timedelta(seconds=20)
 
 
-WorkItem = Union[Work, Tuple[Work, ExecOptions]]
-"""The type of items yielded by a generator created by the `worker` function supplied by user."""
+from yapapi.engine import Engine, Job, WorkItem
+from yapapi.executor.ctx import Work
 
-
-def _unpack_work_item(item: WorkItem) -> Tuple[Work, ExecOptions]:
-    """Extract `Work` object and options from a work item.
-
-    If the item does not specify options, default ones are provided.
-    """
-    if isinstance(item, tuple):
-        return item
-    else:
-        return item, ExecOptions()
-
-
-exescript_ids: Iterator[int] = itertools.count(1)
-"""An iterator providing unique ids used to correlate events related to a single exe script."""
 
 D = TypeVar("D")  # Type var for task data
 R = TypeVar("R")  # Type var for task result
-
-
-class Golem(AsyncContextManager):
-    """Base execution engine containing functions common to all modes of operation."""
-
-    def __init__(
-        self,
-        *,
-        budget: Union[float, Decimal],
-        strategy: Optional[MarketStrategy] = None,
-        subnet_tag: Optional[str] = None,
-        driver: Optional[str] = None,
-        network: Optional[str] = None,
-        event_consumer: Optional[Callable[[Event], None]] = None,
-        stream_output: bool = False,
-        app_key: Optional[str] = None,
-    ):
-        """Initialize the Golem engine.
-
-        :param budget: maximum budget for payments
-        :param strategy: market strategy used to select providers from the market
-            (e.g. LeastExpensiveLinearPayuMS or DummyMS)
-        :param subnet_tag: use only providers in the subnet with the subnet_tag name
-        :param driver: name of the payment driver to use or `None` to use the default driver;
-            only payment platforms with the specified driver will be used
-        :param network: name of the network to use or `None` to use the default network;
-            only payment platforms with the specified network will be used
-        :param event_consumer: a callable that processes events related to the
-            computation; by default it is a function that logs all events
-        :param stream_output: stream computation output from providers
-        :param app_key: optional Yagna application key. If not provided, the default is to
-                        get the value from `YAGNA_APPKEY` environment variable
-        """
-        self._api_config = rest.Configuration(app_key)
-        self._budget_amount = Decimal(budget)
-        self._budget_allocations: List[rest.payment.Allocation] = []
-
-        if not strategy:
-            strategy = LeastExpensiveLinearPayuMS(
-                max_fixed_price=Decimal("1.0"),
-                max_price_for={com.Counter.CPU: Decimal("0.2"), com.Counter.TIME: Decimal("0.1")},
-            )
-            # The factor 0.5 below means that an offer for a provider that failed to confirm
-            # the last agreement proposed to them will have it's score multiplied by 0.5.
-            strategy = DecreaseScoreForUnconfirmedAgreement(strategy, 0.5)
-        self._strategy = strategy
-
-        self._subnet: Optional[str] = subnet_tag
-        self._driver = driver.lower() if driver else DEFAULT_DRIVER
-        self._network = network.lower() if network else DEFAULT_NETWORK
-
-        if not event_consumer:
-            # Use local import to avoid cyclic imports when yapapi.log
-            # is imported by client code
-            from ..log import log_event_repr
-
-            event_consumer = log_event_repr
-
-        # Add buffering to the provided event emitter to make sure
-        # that emitting events will not block
-        self._wrapped_consumer = AsyncWrapper(event_consumer)
-
-        self._stream_output = stream_output
-
-        # initialize the payment structures
-        self._agreements_to_pay: Set[str] = set()
-        self._agreements_accepting_debit_notes: Set[str] = set()
-        self._invoices: Dict[str, rest.payment.Invoice] = dict()
-        self._payment_closing: bool = False
-
-        # a set of `Job` instances used to track jobs - computations or services - started
-        # it can be used to wait until all jobs are finished
-        self._jobs: Set[Job] = set()
-        self._process_invoices_job: Optional[asyncio.Task] = None
-
-        self._services: Set[asyncio.Task] = set()
-        self._stack = AsyncExitStack()
-
-    async def create_demand_builder(
-        self, expiration_time: datetime, payload: Payload
-    ) -> DemandBuilder:
-        """Create a `DemandBuilder` for given `payload` and `expiration_time`."""
-        builder = DemandBuilder()
-        builder.add(Activity(expiration=expiration_time, multi_activity=True))
-        builder.add(NodeInfo(subnet_tag=self._subnet))
-        if self._subnet:
-            builder.ensure(f"({NodeInfoKeys.subnet_tag}={self._subnet})")
-        await builder.decorate(self.payment_decorator, self.strategy, payload)
-        return builder
-
-    @property
-    def driver(self) -> str:
-        """Return the name of the payment driver used by this engine."""
-        return self._driver
-
-    @property
-    def network(self) -> str:
-        """Return the name of the payment network used by this engine."""
-        return self._network
-
-    @property
-    def storage_manager(self):
-        """Return the storage manager used by this engine."""
-        return self._storage_manager
-
-    @property
-    def strategy(self) -> MarketStrategy:
-        """Return the instance of `MarketStrategy` used by this engine."""
-        return self._strategy
-
-    def emit(self, event: events.Event) -> None:
-        """Emit an event to be consumed by this engine's event consumer."""
-        if self._wrapped_consumer:
-            self._wrapped_consumer.async_call(event)
-
-    async def __aenter__(self) -> "Golem":
-        """Initialize resources and start background services used by this engine."""
-
-        try:
-            stack = self._stack
-
-            await stack.enter_async_context(self._wrapped_consumer)
-
-            def report_shutdown(*exc_info):
-                if any(item for item in exc_info):
-                    self.emit(events.ShutdownFinished(exc_info=exc_info))  # noqa
-                else:
-                    self.emit(events.ShutdownFinished())
-
-            stack.push(report_shutdown)
-
-            market_client = await stack.enter_async_context(self._api_config.market())
-            self._market_api = rest.Market(market_client)
-
-            activity_client = await stack.enter_async_context(self._api_config.activity())
-            self._activity_api = rest.Activity(activity_client)
-
-            payment_client = await stack.enter_async_context(self._api_config.payment())
-            self._payment_api = rest.Payment(payment_client)
-
-            self.payment_decorator = Golem.PaymentDecorator(await self._create_allocations())
-
-            # TODO: make the method starting the process_invoices() task an async context manager
-            # to simplify code in __aexit__()
-            loop = asyncio.get_event_loop()
-            self._process_invoices_job = loop.create_task(self._process_invoices())
-            self._services.add(self._process_invoices_job)
-            self._services.add(loop.create_task(self._process_debit_notes()))
-
-            self._storage_manager = await stack.enter_async_context(gftp.provider())
-
-            stack.push_async_exit(self._shutdown)
-
-            return self
-        except:
-            await self.__aexit__(*sys.exc_info())
-            raise
-
-    async def _shutdown(self, *exc_info):
-        """Shutdown this Golem instance."""
-
-        # Importing this at the beginning would cause circular dependencies
-        from ..log import pluralize
-
-        logger.info("Golem is shutting down...")
-        # Wait until all computations are finished
-        await asyncio.gather(*[job.finished.wait() for job in self._jobs])
-        logger.info("All jobs have finished")
-
-        self._payment_closing = True
-
-        for task in self._services:
-            if task is not self._process_invoices_job:
-                task.cancel()
-
-        if self._process_invoices_job and not any(
-            True for job in self._jobs if job.agreements_pool.confirmed > 0
-        ):
-            logger.debug("No need to wait for invoices.")
-            self._process_invoices_job.cancel()
-
-        try:
-            logger.info("Waiting for Golem services to finish...")
-            _, pending = await asyncio.wait(
-                self._services, timeout=10, return_when=asyncio.ALL_COMPLETED
-            )
-            if pending:
-                logger.debug("%s still running: %s", pluralize(len(pending), "service"), pending)
-        except Exception:
-            logger.debug("Got error when waiting for services to finish", exc_info=True)
-
-        if self._agreements_to_pay and self._process_invoices_job:
-            logger.info(
-                "%s still unpaid, waiting for invoices...",
-                pluralize(len(self._agreements_to_pay), "agreement"),
-            )
-            try:
-                await asyncio.wait_for(self._process_invoices_job, timeout=30)
-            except asyncio.TimeoutError:
-                logger.debug("process_invoices_job cancelled")
-            if self._agreements_to_pay:
-                logger.warning("Unpaid agreements: %s", self._agreements_to_pay)
-
-        await asyncio.gather(*[job.finished.wait() for job in self._jobs])
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await self._stack.aclose()
-
-    async def _create_allocations(self) -> rest.payment.MarketDecoration:
-
-        if not self._budget_allocations:
-            async for account in self._payment_api.accounts():
-                driver = account.driver.lower()
-                network = account.network.lower()
-                if (driver, network) != (self._driver, self._network):
-                    logger.debug(
-                        "Not using payment platform `%s`, platform's driver/network "
-                        "`%s`/`%s` is different than requested driver/network `%s`/`%s`",
-                        account.platform,
-                        driver,
-                        network,
-                        self._driver,
-                        self._network,
-                    )
-                    continue
-                logger.debug("Creating allocation using payment platform `%s`", account.platform)
-                allocation = cast(
-                    rest.payment.Allocation,
-                    await self._stack.enter_async_context(
-                        self._payment_api.new_allocation(
-                            self._budget_amount,
-                            payment_platform=account.platform,
-                            payment_address=account.address,
-                            #   TODO what do to with this?
-                            #   expires=self._expires + CFG_INVOICE_TIMEOUT,
-                        )
-                    ),
-                )
-                self._budget_allocations.append(allocation)
-
-            if not self._budget_allocations:
-                raise NoPaymentAccountError(self._driver, self._network)
-
-        allocation_ids = [allocation.id for allocation in self._budget_allocations]
-        return await self._payment_api.decorate_demand(allocation_ids)
-
-    def _get_allocation(
-        self, item: Union[rest.payment.DebitNote, rest.payment.Invoice]
-    ) -> rest.payment.Allocation:
-        try:
-            return next(
-                allocation
-                for allocation in self._budget_allocations
-                if allocation.payment_address == item.payer_addr
-                and allocation.payment_platform == item.payment_platform
-            )
-        except:
-            raise ValueError(f"No allocation for {item.payment_platform} {item.payer_addr}.")
-
-    async def _process_invoices(self) -> None:
-        """Process incoming invoices."""
-
-        async for invoice in self._payment_api.incoming_invoices():
-            if invoice.agreement_id in self._agreements_to_pay:
-                self.emit(
-                    events.InvoiceReceived(
-                        agr_id=invoice.agreement_id,
-                        inv_id=invoice.invoice_id,
-                        amount=invoice.amount,
-                    )
-                )
-                try:
-                    allocation = self._get_allocation(invoice)
-                    await invoice.accept(amount=invoice.amount, allocation=allocation)
-                except CancelledError:
-                    raise
-                except Exception:
-                    self.emit(
-                        events.PaymentFailed(
-                            agr_id=invoice.agreement_id, exc_info=sys.exc_info()  # type: ignore
-                        )
-                    )
-                else:
-                    self._agreements_to_pay.remove(invoice.agreement_id)
-                    assert invoice.agreement_id in self._agreements_accepting_debit_notes
-                    self._agreements_accepting_debit_notes.remove(invoice.agreement_id)
-                    self.emit(
-                        events.PaymentAccepted(
-                            agr_id=invoice.agreement_id,
-                            inv_id=invoice.invoice_id,
-                            amount=invoice.amount,
-                        )
-                    )
-            else:
-                self._invoices[invoice.agreement_id] = invoice
-            if self._payment_closing and not self._agreements_to_pay:
-                break
-
-    async def _process_debit_notes(self) -> None:
-        """Process incoming debit notes."""
-
-        async for debit_note in self._payment_api.incoming_debit_notes():
-            if debit_note.agreement_id in self._agreements_accepting_debit_notes:
-                self.emit(
-                    events.DebitNoteReceived(
-                        agr_id=debit_note.agreement_id,
-                        amount=debit_note.total_amount_due,
-                        note_id=debit_note.debit_note_id,
-                    )
-                )
-                try:
-                    allocation = self._get_allocation(debit_note)
-                    await debit_note.accept(
-                        amount=debit_note.total_amount_due, allocation=allocation
-                    )
-                except CancelledError:
-                    raise
-                except Exception:
-                    self.emit(
-                        events.PaymentFailed(
-                            agr_id=debit_note.agreement_id, exc_info=sys.exc_info()  # type: ignore
-                        )
-                    )
-            if self._payment_closing and not self._agreements_to_pay:
-                break
-
-    async def accept_payments_for_agreement(
-        self, agreement_id: str, *, partial: bool = False
-    ) -> None:
-        """Add given agreement to the set of agreements for which invoices should be accepted."""
-
-        self.emit(events.PaymentPrepared(agr_id=agreement_id))
-        inv = self._invoices.get(agreement_id)
-        if inv is None:
-            self._agreements_to_pay.add(agreement_id)
-            self.emit(events.PaymentQueued(agr_id=agreement_id))
-            return
-        del self._invoices[agreement_id]
-        allocation = self._get_allocation(inv)
-        await inv.accept(amount=inv.amount, allocation=allocation)
-        self.emit(
-            events.PaymentAccepted(agr_id=agreement_id, inv_id=inv.invoice_id, amount=inv.amount)
-        )
-
-    def accept_debit_notes_for_agreement(self, agreement_id: str) -> None:
-        """Add given agreement to the set of agreements for which debit notes should be accepted."""
-        self._agreements_accepting_debit_notes.add(agreement_id)
-
-    def add_job(self, job: "Job"):
-        """Register a job with this engine."""
-        self._jobs.add(job)
-
-    @staticmethod
-    def finalize_job(job: "Job"):
-        """Mark a job as finished."""
-        job.finished.set()
-
-    @dataclass
-    class PaymentDecorator(DemandDecorator):
-        """A `DemandDecorator` that adds payment-related constraints and properties to a Demand."""
-
-        market_decoration: rest.payment.MarketDecoration
-
-        async def decorate_demand(self, demand: DemandBuilder):
-            """Add properties and constraints to a Demand."""
-            for constraint in self.market_decoration.constraints:
-                demand.ensure(constraint)
-            demand.properties.update({p.key: p.value for p in self.market_decoration.properties})
-
-    async def create_activity(self, agreement_id: str):
-        """Create an activity for given `agreement_id`."""
-        return await self._activity_api.new_activity(
-            agreement_id, stream_events=self._stream_output
-        )
-
-    async def process_batches(
-        self,
-        agreement_id: str,
-        activity: rest.activity.Activity,
-        command_generator: AsyncGenerator[WorkItem, Awaitable[List[events.CommandEvent]]],
-    ) -> None:
-        """Send command batches produced by `command_generator` to `activity`."""
-
-        item = await command_generator.__anext__()
-
-        while True:
-
-            batch, exec_options = _unpack_work_item(item)
-
-            # TODO: `task_id` should really be `batch_id`, but then we should also rename
-            # `task_id` field of several events (e.g. `ScriptSent`)
-            script_id = str(next(exescript_ids))
-
-            if batch.timeout:
-                if exec_options.batch_timeout:
-                    logger.warning(
-                        "Overriding batch timeout set with commit(batch_timeout)"
-                        "by the value set in exec options"
-                    )
-                else:
-                    exec_options.batch_timeout = batch.timeout
-
-            batch_deadline = (
-                datetime.now(timezone.utc) + exec_options.batch_timeout
-                if exec_options.batch_timeout
-                else None
-            )
-
-            await batch.prepare()
-            cc = CommandContainer()
-            batch.register(cc)
-            remote = await activity.send(cc.commands(), deadline=batch_deadline)
-            cmds = cc.commands()
-            self.emit(events.ScriptSent(agr_id=agreement_id, script_id=script_id, cmds=cmds))
-
-            async def get_batch_results() -> List[events.CommandEvent]:
-                results = []
-                async for evt_ctx in remote:
-                    evt = evt_ctx.event(agr_id=agreement_id, script_id=script_id, cmds=cmds)
-                    self.emit(evt)
-                    results.append(evt)
-                    if isinstance(evt, events.CommandExecuted) and not evt.success:
-                        raise CommandExecutionError(evt.command, evt.message, evt.stderr)
-
-                self.emit(events.GettingResults(agr_id=agreement_id, script_id=script_id))
-                await batch.post()
-                self.emit(events.ScriptFinished(agr_id=agreement_id, script_id=script_id))
-                await self.accept_payments_for_agreement(agreement_id, partial=True)
-                return results
-
-            loop = asyncio.get_event_loop()
-
-            if exec_options.wait_for_results:
-                # Block until the results are available
-                try:
-                    future_results = loop.create_future()
-                    results = await get_batch_results()
-                    future_results.set_result(results)
-                except Exception:
-                    # Raise the exception in `command_generator` (the `worker` coroutine).
-                    # If the client code is able to handle it then we'll proceed with
-                    # subsequent batches. Otherwise the worker finishes with error.
-                    item = await command_generator.athrow(*sys.exc_info())
-                else:
-                    item = await command_generator.asend(future_results)
-
-            else:
-                # Schedule the coroutine in a separate asyncio task
-                future_results = loop.create_task(get_batch_results())
-                item = await command_generator.asend(future_results)
-
-    async def execute_tasks(
-        self,
-        worker: Callable[
-            [WorkContext, AsyncIterator[Task[D, R]]],
-            AsyncGenerator[WorkItem, Awaitable[List[events.CommandEvent]]],
-        ],
-        data: Union[AsyncIterator[Task[D, R]], Iterable[Task[D, R]]],
-        payload: Payload,
-        max_workers: Optional[int] = None,
-        timeout: Optional[timedelta] = None,
-        budget: Optional[Union[float, Decimal]] = None,
-    ) -> AsyncIterator[Task[D, R]]:
-        """Submit a sequence of tasks to be executed on providers.
-
-        Internally, this method creates an instance of `yapapi.executor.Executor`
-        and calls its `submit()` method with given worker function and sequence of tasks.
-
-        :param worker: an async generator that takes a `WorkContext` object and a sequence
-            of tasks, and generates as sequence of work items to be executed on providers in order
-            to compute given tasks
-        :param data: an iterable or an async generator of `Task` objects to be computed on providers
-        :param payload: specification of the payload that needs to be deployed on providers
-            (for example, a VM runtime package) in order to compute the tasks, passed to
-            the created `Executor` instance
-        :param max_workers: maximum number of concurrent workers, passed to the `Executor` instance
-        :param timeout: timeout for computing all tasks, passed to the `Executor` instance
-        :param budget: budget for computing all tasks, passed to the `Executor` instance
-        :return: an iterator that yields completed `Task` objects
-        """
-
-        kwargs: Dict[str, Any] = {"payload": payload}
-        if max_workers:
-            kwargs["max_workers"] = max_workers
-        if timeout:
-            kwargs["timeout"] = timeout
-        kwargs["budget"] = budget if budget is not None else self._budget_amount
-
-        async with Executor(_engine=self, **kwargs) as executor:
-            async for t in executor.submit(worker, data):
-                yield t
-
-    async def run_service(
-        self,
-        service_class: Type["Service"],
-        num_instances: int = 1,
-        payload: Optional[Payload] = None,
-        expiration: Optional[datetime] = None,
-    ) -> "Cluster":
-        """Run a number of instances of a service represented by a given `Service` subclass.
-
-        :param service_class: a subclass of `Service` that represents the service to be run
-        :param num_instances: optional number of service instances to run, defaults to a single
-            instance
-        :param payload: optional runtime definition for the service; if not provided, the
-            payload specified by the `get_payload()` method of `service_class` is used
-        :param expiration: optional expiration datetime for the service
-        :return: a `Cluster` of service instances
-        """
-
-        from yapapi.services import Cluster  # avoid circular dependency
-
-        payload = payload or await service_class.get_payload()
-
-        if not payload:
-            raise ValueError(
-                f"No payload returned from {service_class.__name__}.get_payload()"
-                " nor given in the `payload` argument."
-            )
-
-        cluster = Cluster(
-            engine=self,
-            service_class=service_class,
-            payload=payload,
-            num_instances=num_instances,
-            expiration=expiration,
-        )
-        await self._stack.enter_async_context(cluster)
-        cluster.spawn_instances()
-        return cluster
-
-
-class Job:
-    """Functionality related to a single job.
-
-    Responsible for posting a Demand to market and collecting Offer proposals for the Demand.
-    """
-
-    def __init__(
-        self,
-        engine: Golem,
-        expiration_time: datetime,
-        payload: Payload,
-    ):
-        """Initialize a `Job` instance.
-
-        param engine: a `Golem` engine which will run this job
-        param expiration_time: expiration time for the job; all agreements created for this job
-            must expire before this date
-        param payload: definition of a service runtime or a runtime package that needs to
-            be deployed on providers for executing this job
-        """
-
-        self.id = str(uuid.uuid4())
-        self.engine = engine
-        self.offers_collected: int = 0
-        self.proposals_confirmed: int = 0
-        self.expiration_time: datetime = expiration_time
-        self.payload: Payload = payload
-
-        self.agreements_pool = AgreementsPool(self.engine.emit)
-        self.finished = asyncio.Event()
-
-    async def _handle_proposal(
-        self,
-        proposal: OfferProposal,
-        demand_builder: DemandBuilder,
-    ) -> events.Event:
-        """Handle a single `OfferProposal`.
-
-        A `proposal` is scored and then can be rejected, responded with
-        a counter-proposal or stored in an agreements pool to be used
-        for negotiating an agreement.
-        """
-
-        async def reject_proposal(reason: str) -> events.ProposalRejected:
-            """Reject `proposal` due to given `reason`."""
-            await proposal.reject(reason)
-            return events.ProposalRejected(prop_id=proposal.id, reason=reason)
-
-        score = await self.engine._strategy.score_offer(proposal, self.agreements_pool)
-        logger.debug(
-            "Scored offer %s, provider: %s, strategy: %s, score: %f",
-            proposal.id,
-            proposal.props.get("golem.node.id.name"),
-            type(self.engine._strategy).__name__,
-            score,
-        )
-
-        if score < SCORE_NEUTRAL:
-            return await reject_proposal("Score too low")
-
-        if not proposal.is_draft:
-            # Proposal is not yet a draft of an agreement
-
-            # Check if any of the supported payment platforms matches the proposal
-            common_platforms = self._get_common_payment_platforms(proposal)
-            if common_platforms:
-                demand_builder.properties["golem.com.payment.chosen-platform"] = next(
-                    iter(common_platforms)
-                )
-            else:
-                # reject proposal if there are no common payment platforms
-                return await reject_proposal("No common payment platform")
-
-            # Check if the timeout for debit note acceptance is not too low
-            timeout = proposal.props.get(DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP)
-            if timeout:
-                if timeout < DEBIT_NOTE_MIN_TIMEOUT:
-                    return await reject_proposal("Debit note acceptance timeout is too short")
-                else:
-                    demand_builder.properties[DEBIT_NOTE_ACCEPTANCE_TIMEOUT_PROP] = timeout
-
-            await proposal.respond(demand_builder.properties, demand_builder.constraints)
-            return events.ProposalResponded(prop_id=proposal.id)
-
-        else:
-            # It's a draft agreement
-            await self.agreements_pool.add_proposal(score, proposal)
-            return events.ProposalConfirmed(prop_id=proposal.id)
-
-    async def _find_offers_for_subscription(
-        self,
-        subscription: Subscription,
-        demand_builder: DemandBuilder,
-    ) -> None:
-        """Create a market subscription and repeatedly collect offer proposals for it.
-
-        Collected proposals are processed concurrently using a bounded number
-        of asyncio tasks.
-
-        :param state: A state related to a call to `Executor.submit()`
-        """
-        max_number_of_tasks = 5
-
-        try:
-            proposals = subscription.events()
-        except Exception as ex:
-            self.engine.emit(events.CollectFailed(sub_id=subscription.id, reason=str(ex)))
-            raise
-
-        # A semaphore is used to limit the number of handler tasks
-        semaphore = asyncio.Semaphore(max_number_of_tasks)
-
-        async for proposal in proposals:
-
-            self.engine.emit(
-                events.ProposalReceived(prop_id=proposal.id, provider_id=proposal.issuer)
-            )
-            self.offers_collected += 1
-
-            async def handler(proposal_):
-                """Wrap `_handle_proposal()` method with error handling."""
-                try:
-                    event = await self._handle_proposal(proposal_, demand_builder)
-                    assert isinstance(event, events.ProposalEvent)
-                    self.engine.emit(event)
-                    if isinstance(event, events.ProposalConfirmed):
-                        self.proposals_confirmed += 1
-                except CancelledError:
-                    raise
-                except Exception:
-                    with contextlib.suppress(Exception):
-                        self.engine.emit(
-                            events.ProposalFailed(
-                                prop_id=proposal_.id, exc_info=sys.exc_info()  # type: ignore
-                            )
-                        )
-                finally:
-                    semaphore.release()
-
-            # Create a new handler task
-            await semaphore.acquire()
-            asyncio.get_event_loop().create_task(handler(proposal))
-
-    async def find_offers(self) -> None:
-        """Create demand subscription and process offers.
-
-        When the subscription expires, create a new one. And so on...
-        """
-
-        builder = await self.engine.create_demand_builder(self.expiration_time, self.payload)
-
-        while True:
-            try:
-                subscription = await builder.subscribe(self.engine._market_api)
-                self.engine.emit(events.SubscriptionCreated(sub_id=subscription.id))
-            except Exception as ex:
-                self.engine.emit(events.SubscriptionFailed(reason=str(ex)))
-                raise
-            async with subscription:
-                await self._find_offers_for_subscription(subscription, builder)
-
-    # TODO: move to Golem
-    def _get_common_payment_platforms(self, proposal: rest.market.OfferProposal) -> Set[str]:
-        prov_platforms = {
-            property.split(".")[4]
-            for property in proposal.props
-            if property.startswith("golem.com.payment.platform.") and property is not None
-        }
-        if not prov_platforms:
-            prov_platforms = {"NGNT"}
-        req_platforms = {
-            allocation.payment_platform
-            for allocation in self.engine._budget_allocations
-            if allocation.payment_platform is not None
-        }
-        return req_platforms.intersection(prov_platforms)
-
-
-DEFAULT_GET_OFFERS_TIMEOUT = timedelta(seconds=20)
 
 
 class Executor(AsyncContextManager):
@@ -852,7 +83,7 @@ class Executor(AsyncContextManager):
         payload: Optional[Payload] = None,
         max_workers: int = 5,
         timeout: timedelta = DEFAULT_EXECUTOR_TIMEOUT,
-        _engine: Golem,
+        _engine: Engine,
     ):
         """Initialize the `Executor` to use a specific Golem `_engine`."""
 
@@ -904,7 +135,7 @@ class Executor(AsyncContextManager):
         timeout: timedelta = DEFAULT_EXECUTOR_TIMEOUT,
         package: Optional[Payload] = None,
         payload: Optional[Payload] = None,
-        _engine: Optional[Golem] = None,
+        _engine: Optional[Engine] = None,
     ):
         """Initialize an `Executor`.
 
@@ -942,7 +173,7 @@ class Executor(AsyncContextManager):
             if not budget:
                 raise ValueError("Missing value for `budget` argument.")
 
-            self._engine = Golem(
+            self._engine = Engine(
                 budget=budget,
                 strategy=strategy,
                 subnet_tag=subnet_tag,

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -15,7 +15,7 @@ from typing import (
 )
 from typing_extensions import AsyncGenerator
 
-from yapapi.engine import Engine, WorkItem
+from yapapi.engine import _Engine, WorkItem
 from yapapi.executor import events, Executor
 from yapapi.executor.ctx import WorkContext
 from yapapi.executor.task import Task
@@ -26,7 +26,7 @@ D = TypeVar("D")  # Type var for task data
 R = TypeVar("R")  # Type var for task result
 
 
-class Golem(Engine):
+class Golem(_Engine):
     async def execute_tasks(
         self,
         worker: Callable[

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -1,0 +1,108 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+)
+from typing_extensions import AsyncGenerator
+
+from yapapi.engine import Engine, WorkItem
+from yapapi.executor import events, Executor
+from yapapi.executor.ctx import WorkContext
+from yapapi.executor.task import Task
+from yapapi.payload import Payload
+from yapapi.services import Cluster, Service
+
+D = TypeVar("D")  # Type var for task data
+R = TypeVar("R")  # Type var for task result
+
+
+class Golem(Engine):
+    async def execute_tasks(
+        self,
+        worker: Callable[
+            [WorkContext, AsyncIterator[Task[D, R]]],
+            AsyncGenerator[WorkItem, Awaitable[List[events.CommandEvent]]],
+        ],
+        data: Union[AsyncIterator[Task[D, R]], Iterable[Task[D, R]]],
+        payload: Payload,
+        max_workers: Optional[int] = None,
+        timeout: Optional[timedelta] = None,
+        budget: Optional[Union[float, Decimal]] = None,
+    ) -> AsyncIterator[Task[D, R]]:
+        """Submit a sequence of tasks to be executed on providers.
+
+        Internally, this method creates an instance of `yapapi.executor.Executor`
+        and calls its `submit()` method with given worker function and sequence of tasks.
+
+        :param worker: an async generator that takes a `WorkContext` object and a sequence
+            of tasks, and generates as sequence of work items to be executed on providers in order
+            to compute given tasks
+        :param data: an iterable or an async generator of `Task` objects to be computed on providers
+        :param payload: specification of the payload that needs to be deployed on providers
+            (for example, a VM runtime package) in order to compute the tasks, passed to
+            the created `Executor` instance
+        :param max_workers: maximum number of concurrent workers, passed to the `Executor` instance
+        :param timeout: timeout for computing all tasks, passed to the `Executor` instance
+        :param budget: budget for computing all tasks, passed to the `Executor` instance
+        :return: an iterator that yields completed `Task` objects
+        """
+
+        kwargs: Dict[str, Any] = {"payload": payload}
+        if max_workers:
+            kwargs["max_workers"] = max_workers
+        if timeout:
+            kwargs["timeout"] = timeout
+        kwargs["budget"] = budget if budget is not None else self._budget_amount
+
+        async with Executor(_engine=self, **kwargs) as executor:
+            async for t in executor.submit(worker, data):
+                yield t
+
+    async def run_service(
+        self,
+        service_class: Type[Service],
+        num_instances: int = 1,
+        payload: Optional[Payload] = None,
+        expiration: Optional[datetime] = None,
+    ) -> Cluster:
+        """Run a number of instances of a service represented by a given `Service` subclass.
+
+        :param service_class: a subclass of `Service` that represents the service to be run
+        :param num_instances: optional number of service instances to run, defaults to a single
+            instance
+        :param payload: optional runtime definition for the service; if not provided, the
+            payload specified by the `get_payload()` method of `service_class` is used
+        :param expiration: optional expiration datetime for the service
+        :return: a `Cluster` of service instances
+        """
+
+        from .services import Cluster  # avoid circular dependency
+
+        payload = payload or await service_class.get_payload()
+
+        if not payload:
+            raise ValueError(
+                f"No payload returned from {service_class.__name__}.get_payload()"
+                " nor given in the `payload` argument."
+            )
+
+        cluster = Cluster(
+            engine=self,
+            service_class=service_class,
+            payload=payload,
+            num_instances=num_instances,
+            expiration=expiration,
+        )
+        await self._stack.enter_async_context(cluster)
+        cluster.spawn_instances()
+        return cluster

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -19,7 +19,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Final
 
-from yapapi import Golem, Job, rest
+from yapapi import Engine, Job, rest
 from yapapi.executor import events
 from yapapi.executor.ctx import WorkContext
 from yapapi.payload import Payload
@@ -212,7 +212,7 @@ class Cluster(AsyncContextManager):
 
     def __init__(
         self,
-        engine: "Golem",
+        engine: "Engine",
         service_class: Type[Service],
         payload: Payload,
         num_instances: int = 1,

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -19,7 +19,8 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Final
 
-from yapapi import Engine, Job, rest
+from yapapi import rest
+from yapapi.engine import _Engine, Job
 from yapapi.executor import events
 from yapapi.executor.ctx import WorkContext
 from yapapi.payload import Payload
@@ -212,7 +213,7 @@ class Cluster(AsyncContextManager):
 
     def __init__(
         self,
-        engine: "Engine",
+        engine: "_Engine",
         service_class: Type[Service],
         payload: Payload,
         num_instances: int = 1,


### PR DESCRIPTION
Separating `Golem` and `Executor` was not straightforward, since:
* `Executor` creates an instance of `Golem` in its `__init__()` method
* `Golem` creates an instance of `Executor` in its `execute_tasks()` method

For this reason, the class `Golem` has been split into a mini-hierarchy: 
* new class `Engine`, including everything `Golem` included, except the high-level methods `run_service()` and `execute_tasks()`
* its subclass `Golem`, containing just the two methods mentioned above

The class `Engine` (together with `Job` and some utility functions) is in module `yapapi.engine`, while `Golem` is in `yapapi.golem`. `Executor` needs to import only `yapapi.engine`, and `Golem` may import `yapapi.executor` without creating
circular depdendencies.

All this was done rather quickly, there's probably much to be done, like adding the docstrings in `golem.py` and fixing the docstrings and comments elsewhere.

Also, some modules should be removed from `yapapi.executor` package, as they contain code that is used by `Engine` and `Golem` rather than (or in addition to) `Executor`, for example `agreements_pool.py`.

**UPDATE**: Further changes:
- rename class `yapapi.engine.Engine` to `yapapi.engine._Engine`, to indicate that *it's not* part of the public API
- ~move `strategy.py` (a module with `MarketStrategy` class, belonging to the public API) from `yapapi/executor/` to `yapapi/`~ -- this will be done in a separate PR, along with some other modules that currently reside in `yapapi/executor/` but should not
