### PR TITLE
Yagna datetime format in logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ colorama = "^0.4.4"
 # It will be then installable with `poetry install -E integration-tests`.
 # Note that putting `goth` in `poetry.dev-dependencies` instead of `poetry.dependencies`
 # would not work: see https://github.com/python-poetry/poetry/issues/129.
-goth = { version = "^0.3", optional = true, python = "^3.8.0" }
+goth = { version = "^0.4", optional = true, python = "^3.8.0" }
 Deprecated = "^1.2.12"
 python-statemachine = "^0.8.0"
 

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -64,6 +64,17 @@ executor_logger = logging.getLogger("yapapi.executor")
 _agreements_pool_logger = logging.getLogger("yapapi.agreements_pool")
 
 
+class _YagnaDatetimeFormatter(logging.Formatter):
+    """Custom log Formatter that formats datetime using the same convention yagna uses."""
+
+    LOCAL_TZ = datetime.now(timezone.utc).astimezone().tzinfo
+
+    def formatTime(self, record: logging.LogRecord, datefmt=None):
+        """Format datetime; example: `2021-06-11T14:55:43.156.123+0200`."""
+        dt = datetime.fromtimestamp(record.created, tz=self.LOCAL_TZ)
+        return dt.strftime(f"%Y-%m-%dT%H:%M:%S.{dt.microsecond / 1000}%z")
+
+
 def enable_default_logger(
     format_: str = "[%(asctime)s %(levelname)s %(name)s] %(message)s",
     log_file: Optional[str] = None,
@@ -79,8 +90,8 @@ def enable_default_logger(
     logger = logging.getLogger("yapapi")
     logger.setLevel(logging.DEBUG)
     logger.disabled = False
-    formatter = logging.Formatter(format_)
 
+    formatter = _YagnaDatetimeFormatter(fmt=format_)
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
     console_handler.setLevel(logging.INFO)

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -72,7 +72,8 @@ class _YagnaDatetimeFormatter(logging.Formatter):
     def formatTime(self, record: logging.LogRecord, datefmt=None):
         """Format datetime; example: `2021-06-11T14:55:43.156.123+0200`."""
         dt = datetime.fromtimestamp(record.created, tz=self.LOCAL_TZ)
-        return dt.strftime(f"%Y-%m-%dT%H:%M:%S.{dt.microsecond / 1000}%z")
+        millis = f"{(dt.microsecond // 1000):03d}"
+        return dt.strftime(f"%Y-%m-%dT%H:%M:%S.{millis}%z")
 
 
 def enable_default_logger(


### PR DESCRIPTION
Resolves #388 

Example log line after the changes in this PR:
```
[2021-06-11T14:54:54.734.995+0200 DEBUG yapapi] Yapapi version: 0.6.0-alpha.1, script: examples/three_clusters.py, working directory: /home/azawlocki/golem/yapapi
```