### PR TITLE
Make goth runs compatible with yagna 0.7

### DIFF
--- a/.github/workflows/goth-nightly.yml
+++ b/.github/workflows/goth-nightly.yml
@@ -7,13 +7,17 @@ on:
 
 jobs:
   goth-tests:
-    name: Run integration tests (stable)
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ["master", "b0.6"]
+    name: Run integration tests (nightly) on ${{ matrix.branch }}
     runs-on: goth
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: 'b0.5'
+          ref: ${{ matrix.branch }}
 
       - name: Configure python
         uses: actions/setup-python@v2

--- a/.github/workflows/goth.yml
+++ b/.github/workflows/goth.yml
@@ -1,4 +1,4 @@
-name: integration-test
+name: Goth (PR and push)
 
 on:
   push:
@@ -9,17 +9,12 @@ on:
     branches:
       - master
       - b0.*
-  schedule:
-    # run this workflow every day at 1:30 AM UTC
-    - cron: '30 1 * * *'
 
 jobs:
-
   goth-tests:
     name: Run integration tests
     runs-on: goth
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ colorama = "^0.4.4"
 # It will be then installable with `poetry install -E integration-tests`.
 # Note that putting `goth` in `poetry.dev-dependencies` instead of `poetry.dependencies`
 # would not work: see https://github.com/python-poetry/poetry/issues/129.
-goth = { version = "^0.3", optional = true, python = "^3.8.0" }
+goth = { version = "^0.4", optional = true, python = "^3.8.0" }
 Deprecated = "^1.2.12"
 python-statemachine = "^0.8.0"
 


### PR DESCRIPTION
- updated `goth` version to `0.4+`
- switched to using a matrix job strategy instead of two separate `schedule` triggers for nightlies
- renamed the push and PR `goth` workflow (along with its file)