### PR TITLE
Repeat payment api calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.6.0"
+version = "0.6.1-alpha.0"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>", "GolemFactory <contact@golem.network>"]
 license = "LGPL-3.0-or-later"

--- a/tests/rest/test_repeat_on_error.py
+++ b/tests/rest/test_repeat_on_error.py
@@ -45,7 +45,7 @@ async def test_repeat_on_error(max_tries, exceptions, calls_expected, expected_e
 
     calls_made = 0
 
-    @repeat_on_error(max_tries=max_tries)
+    @repeat_on_error(max_tries=max_tries, interval=0.0)
     async def request():
         nonlocal calls_made, exceptions
         calls_made += 1

--- a/tests/rest/test_repeat_on_timeout.py
+++ b/tests/rest/test_repeat_on_timeout.py
@@ -1,0 +1,92 @@
+import asyncio
+
+import pytest
+
+import ya_activity
+import ya_market
+import ya_payment
+
+from yapapi.rest.common import repeat_on_timeout, SuppressedExceptions, is_timeout_exception
+
+
+@pytest.mark.parametrize(
+    "max_tries, exceptions, calls_expected, expected_error",
+    [
+        (1, [], 1, None),
+        (1, [asyncio.TimeoutError()], 1, asyncio.TimeoutError),
+        (1, [ya_activity.ApiException(408)], 1, ya_activity.ApiException),
+        (1, [ya_activity.ApiException(500)], 1, ya_activity.ApiException),
+        (1, [ValueError()], 1, ValueError),
+        #
+        (2, [], 1, None),
+        (2, [asyncio.TimeoutError()], 2, None),
+        (2, [ya_activity.ApiException(408)], 2, None),
+        (2, [ya_market.ApiException(408)], 2, None),
+        (2, [ya_payment.ApiException(408)], 2, None),
+        (2, [ya_activity.ApiException(500)], 1, ya_activity.ApiException),
+        (2, [ValueError()], 1, ValueError),
+        (2, [asyncio.TimeoutError()] * 2, 2, asyncio.TimeoutError),
+        #
+        (3, [], 1, None),
+        (3, [asyncio.TimeoutError()], 2, None),
+        (3, [ya_activity.ApiException(408)], 2, None),
+        (3, [asyncio.TimeoutError()] * 2, 3, None),
+        (3, [asyncio.TimeoutError()] * 3, 3, asyncio.TimeoutError),
+        (3, [ya_activity.ApiException(500)], 1, ya_activity.ApiException),
+        (3, [asyncio.TimeoutError(), ValueError()], 2, ValueError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_repeat_on_timeout(max_tries, exceptions, calls_expected, expected_error):
+
+    calls_made = 0
+
+    @repeat_on_timeout(max_tries=max_tries)
+    async def request():
+        nonlocal calls_made, exceptions
+        calls_made += 1
+        if exceptions:
+            e = exceptions[0]
+            exceptions = exceptions[1:]
+            raise e
+        return True
+
+    try:
+        await request()
+    except Exception as e:
+        assert expected_error is not None, f"Unexpected exception: {e}"
+        assert isinstance(e, expected_error), f"Expected an {expected_error}, got {e}"
+    assert calls_made == calls_expected, f"{calls_made} attempts were made, expected {num_calls}"
+
+
+@pytest.mark.asyncio
+async def test_suppressed_exceptions():
+
+    async with SuppressedExceptions(is_timeout_exception) as se:
+        pass
+    assert se.exception is None
+
+    async with SuppressedExceptions(is_timeout_exception) as se:
+        raise asyncio.TimeoutError()
+    assert isinstance(se.exception, asyncio.TimeoutError)
+
+    with pytest.raises(AssertionError):
+        async with SuppressedExceptions(is_timeout_exception):
+            raise AssertionError()
+
+
+@pytest.mark.asyncio
+async def test_suppressed_exceptions_with_return():
+    async def success():
+        return "success"
+
+    async def failure():
+        raise asyncio.TimeoutError()
+
+    async def func(request):
+        async with SuppressedExceptions(is_timeout_exception):
+            return await request
+        return "failure"  # noqa
+
+    assert await func(success()) == "success"
+    assert await func(failure()) == "failure"

--- a/yapapi/rest/common.py
+++ b/yapapi/rest/common.py
@@ -18,7 +18,7 @@ def is_intermittent_error(e: Exception) -> bool:
 
     is_timeout_exception = isinstance(e, asyncio.TimeoutError) or (
         isinstance(e, (ya_activity.ApiException, ya_market.ApiException, ya_payment.ApiException))
-        and e.status == 408
+        and e.status in (408, 504)
     )
 
     return (

--- a/yapapi/rest/common.py
+++ b/yapapi/rest/common.py
@@ -56,7 +56,7 @@ class SuppressedExceptions:
 def repeat_on_error(
     max_tries: int,
     condition: Callable[[Exception], bool] = is_intermittent_error,
-    interval: float = 0.0,
+    interval: float = 1.0,
 ):
     """Decorate a function to repeat calls up to `max_tries` times when errors occur.
 

--- a/yapapi/rest/common.py
+++ b/yapapi/rest/common.py
@@ -1,0 +1,89 @@
+import asyncio
+import functools
+import logging
+from typing import Callable, Optional
+
+import aiohttp
+
+import ya_market
+import ya_activity
+import ya_payment
+
+
+logger = logging.getLogger(__name__)
+
+
+def is_timeout_exception(e: Exception) -> bool:
+    """Check if `e` indicates a client-side or server-side timeout error."""
+
+    # `asyncio.TimeoutError` is raised on client-side timeouts
+    if isinstance(e, asyncio.TimeoutError):
+        return True
+
+    # `ApiException(408)` is raised on server-side timeouts
+    if isinstance(e, (ya_activity.ApiException, ya_market.ApiException, ya_payment.ApiException)):
+        return e.status == 408
+
+    return False
+
+
+def is_recoverable_exception(e: Exception) -> bool:
+    """Check if `e` indicates that we should retry the operation that raised it."""
+
+    return is_timeout_exception(e) or isinstance(e, aiohttp.ServerDisconnectedError)
+
+
+class SuppressedExceptions:
+    """An async context manager for suppressing exception satisfying given test function."""
+
+    exception: Optional[Exception]
+
+    def __init__(
+        self, should_suppress: Callable[[Exception], bool], report_exceptions: bool = True
+    ):
+        self._should_suppress = should_suppress
+        self._report_exceptions = report_exceptions
+        self.exception = None
+
+    async def __aenter__(self) -> "SuppressedExceptions":
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        if exc_value and self._should_suppress(exc_value):
+            self.exception = exc_value
+            if self._report_exceptions:
+                logger.debug(
+                    "Exception suppressed: %r", exc_value, exc_info=(exc_type, exc_value, traceback)
+                )
+            return True
+        return False
+
+
+def repeat_on_timeout(max_tries: int, interval: float = 0.0):
+    """Decorate a function to repeat calls up to `max_tries` times when timeout errors occur."""
+
+    def decorator(func):
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            """Make at most `max_tries` attempts to call `func`."""
+
+            for try_num in range(1, max_tries + 1):
+
+                if try_num > 1:
+                    await asyncio.sleep(interval)
+
+                async with SuppressedExceptions(is_timeout_exception, False) as se:
+                    return await func(*args, **kwargs)
+
+                assert se.exception  # noqa (unreachable)
+                repeat = try_num < max_tries
+                msg = f"API call timed out (attempt {try_num}/{max_tries}), "
+                msg += f"retrying in {interval} s" if repeat else "giving up"
+                # Don't print traceback if this was the last attempt, let the caller do it.
+                logger.debug(msg, exc_info=repeat)
+                if not repeat:
+                    raise se.exception
+
+        return wrapper
+
+    return decorator

--- a/yapapi/rest/market.py
+++ b/yapapi/rest/market.py
@@ -9,7 +9,7 @@ from typing_extensions import Awaitable, AsyncContextManager
 
 from ya_market import ApiClient, ApiException, RequestorApi, models  # type: ignore
 
-from .common import SuppressedExceptions, is_recoverable_exception
+from .common import is_intermittent_error, SuppressedExceptions
 from ..props import Model
 
 
@@ -196,7 +196,7 @@ class Subscription(object):
 
             proposals = []
             try:
-                async with SuppressedExceptions(is_recoverable_exception):
+                async with SuppressedExceptions(is_intermittent_error):
                     proposals = await self._api.collect_offers(self._id, timeout=5, max_events=10)
             except ApiException as ex:
                 if ex.status == 404:

--- a/yapapi/rest/payment.py
+++ b/yapapi/rest/payment.py
@@ -7,6 +7,7 @@ from typing import Optional, AsyncIterator, cast, Iterable, Union, List
 from decimal import Decimal
 from datetime import datetime, timezone, timedelta
 from dataclasses import dataclass
+from .common import is_recoverable_exception, repeat_on_timeout, SuppressedExceptions
 from .resource import ResourceCtx
 
 
@@ -18,6 +19,7 @@ class Invoice(yap.Invoice):
         self.__dict__.update(**_base.__dict__)
         self._api: RequestorApi = _api
 
+    @repeat_on_timeout(max_tries=5)
     async def accept(self, *, amount: Union[Decimal, str], allocation: "Allocation"):
         acceptance = yap.Acceptance(total_amount_accepted=str(amount), allocation_id=allocation.id)
         await self._api.accept_invoice(self.invoice_id, acceptance)
@@ -28,6 +30,7 @@ class DebitNote(yap.DebitNote):
         self.__dict__.update(**_base.__dict__)
         self._api: RequestorApi = _api
 
+    @repeat_on_timeout(max_tries=5)
     async def accept(self, *, amount: Union[Decimal, str], allocation: "Allocation"):
         acceptance = yap.Acceptance(total_amount_accepted=str(amount), allocation_id=allocation.id)
         await self._api.accept_debit_note(self.debit_note_id, acceptance)
@@ -67,6 +70,7 @@ class Allocation(_Link):
     expires: Optional[datetime]
     "Allocation expiration timestamp"
 
+    @repeat_on_timeout(max_tries=5)
     async def details(self) -> AllocationDetails:
         details: yap.Allocation = await self._api.get_allocation(self.id)
         return AllocationDetails(
@@ -74,6 +78,7 @@ class Allocation(_Link):
             remaining_amount=Decimal(details.remaining_amount),
         )
 
+    @repeat_on_timeout(max_tries=5)
     async def delete(self):
         await self._api.release_allocation(self.id)
 
@@ -191,6 +196,7 @@ class Payment(object):
     async def decorate_demand(self, ids: List[str]) -> yap.MarketDecoration:
         return await self._api.get_demand_decorations(ids)
 
+    @repeat_on_timeout(max_tries=5)
     async def debit_note(self, debit_note_id: str) -> DebitNote:
         debit_note = await self._api.get_debit_note(debit_note_id)
         return DebitNote(_api=self._api, _base=debit_note)
@@ -200,13 +206,13 @@ class Payment(object):
         for invoice_obj in cast(Iterable[yap.Invoice], await self._api.get_invoices()):
             yield Invoice(_api=self._api, _base=invoice_obj)
 
+    @repeat_on_timeout(max_tries=5)
     async def invoice(self, invoice_id: str) -> Invoice:
         invoice_obj = await self._api.get_invoice(invoice_id)
         return Invoice(_api=self._api, _base=invoice_obj)
 
     def incoming_invoices(self) -> AsyncIterator[Invoice]:
         ts = datetime.now(timezone.utc)
-        api = self._api
 
         async def fetch(init_ts: datetime):
             ts = init_ts
@@ -214,7 +220,9 @@ class Payment(object):
                 # In the current version of `ya-aioclient` the method `get_invoice_events`
                 # incorrectly accepts `timeout` parameter, while the server uses `pollTimeout`
                 # events = await api.get_invoice_events(poll_timeout=5, after_timestamp=ts)
-                events = await api.get_invoice_events(after_timestamp=ts)
+                events = []
+                async with SuppressedExceptions(is_recoverable_exception):
+                    events = await self._api.get_invoice_events(after_timestamp=ts)
                 for ev in events:
                     logger.debug("Received invoice event: %r, type: %s", ev, ev.__class__)
                     if isinstance(ev, yap.InvoiceReceivedEvent):
@@ -235,7 +243,9 @@ class Payment(object):
         async def fetch(init_ts: datetime):
             ts = init_ts
             while True:
-                events = await self._api.get_debit_note_events(after_timestamp=ts)
+                events = []
+                async with SuppressedExceptions(is_recoverable_exception):
+                    events = await self._api.get_debit_note_events(after_timestamp=ts)
                 for ev in events:
                     logger.debug("Received debit note event: %r, type: %s", ev, ev.__class__)
                     if isinstance(ev, yap.DebitNoteReceivedEvent):


### PR DESCRIPTION
This brings https://github.com/golemfactory/yapapi/pull/358 (via cherry-picking then squashing commits) to `b0.6`.

The difference between this PR and #358 is that the default interval between subsequent attempts is 1s (as in `yajsapi`) not 0s.