### PR TITLE
Use dynamic stable branch in goth nightly

### DIFF
--- a/.github/workflows/goth-nightly.yml
+++ b/.github/workflows/goth-nightly.yml
@@ -6,13 +6,37 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
+  prepare-matrix:
+    name: Prepare matrix JSON
+    runs-on: ubuntu-latest
+    outputs:
+      matrix-json: ${{ steps.get-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # finds branches with names matching 'b[0-9](\.[0-9])+' (e.g. b0.6) and returns the one with highest version
+      - name: Get latest stable branch
+        id: latest-stable
+        # sed removes leading whitespaces and '*' characters (git uses it to indicate the current branch)
+        run: |
+          branch=$(git branch -a | sed 's/remotes\/origin\///' | sed 's/^[ \t*]*//' | grep -E '^b[0-9](\.[0-9])+$' | sort -Vr | head -1)
+          echo "::set-output name=branch::$branch"
+
+      # prepares JSON object representing strategy matrix which contains two 'branch' variants: master and latest stable
+      - name: Get matrix JSON
+        id: get-matrix
+        run: echo "::set-output name=matrix::{\"include\":[{\"branch\":\"master\"},{\"branch\":\"${{ steps.latest-stable.outputs.branch }}\"}]}"
+
   goth-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        branch: ["master", "b0.6"]
-    name: Run integration tests (nightly) on ${{ matrix.branch }}
     runs-on: goth
+    needs: prepare-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix-json) }}
+      fail-fast: false
+    name: Run integration tests (nightly) on ${{ matrix.branch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Additional improvement to: https://github.com/golemfactory/yagna-sdk-team/issues/122

This adds a job which obtains the latest stable branch name and uses that name to generate a run matrix definition for the proper testing job.
Doing so removes the need for manually updating the workflow file whenever there's a new stable branch created in the repo.