### PR TITLE
Error handling in Services._run_instance()

### DIFF
--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -28,7 +28,6 @@ if sys.version_info >= (3, 7):
 else:
     from async_exit_stack import AsyncExitStack  # type: ignore
 
-
 from yapapi import rest, events
 from yapapi.agreements_pool import AgreementsPool
 from yapapi.ctx import CommandContainer, ExecOptions, Work
@@ -524,7 +523,13 @@ class _Engine(AsyncContextManager):
             await batch.prepare()
             cc = CommandContainer()
             batch.register(cc)
-            remote = await activity.send(cc.commands(), deadline=batch_deadline)
+
+            try:
+                remote = await activity.send(cc.commands(), deadline=batch_deadline)
+            except Exception:
+                item = await command_generator.athrow(*sys.exc_info())
+                continue
+
             cmds = cc.commands()
             self.emit(events.ScriptSent(agr_id=agreement_id, script_id=script_id, cmds=cmds))
 

--- a/yapapi/rest/activity.py
+++ b/yapapi/rest/activity.py
@@ -100,7 +100,20 @@ class Result:
     message: Optional[str]
 
 
-class CommandExecutionError(Exception):
+class BatchError(Exception):
+    """An error that occurs during execution of a batch of commands on a provider.
+
+    The error may originate on the provider side, for example when a remote command
+    returns a non-zero exit code (`CommandExecutionError'), or on the requestor side,
+    for example when a time within which the batch of commands should finish executing
+    elapses (`BatchTimeoutError`).
+
+    Errors of this class are passed by the engine to user code (a worker function
+    or a service handler) which may catch them and attempt a recovery.
+    """
+
+
+class CommandExecutionError(BatchError):
     """An exception that indicates that a command failed on a provider."""
 
     command: str
@@ -126,7 +139,7 @@ class CommandExecutionError(Exception):
         return msg
 
 
-class BatchTimeoutError(Exception):
+class BatchTimeoutError(BatchError):
     """An exception that indicates that an execution of a batch of commands timed out."""
 
 

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -460,7 +460,7 @@ class Cluster(AsyncContextManager):
                         fut_result = yield batch
                     except BatchError:
                         # Throw the error into the service code so it can be handled there
-                        logger.warning("Command execution error", exc_info=True)
+                        logger.debug("Batch execution failed", exc_info=True)
                         batch_task = loop.create_task(handler.athrow(*sys.exc_info()))
                     except Exception:
                         # Could be an ApiException thrown in call_exec or get_exec_batch_results

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -5,9 +5,10 @@ from dataclasses import dataclass, field
 from datetime import timedelta, datetime, timezone
 import enum
 import logging
-from typing import Any, AsyncContextManager, List, Optional, Set, Type
 import statemachine  # type: ignore
 import sys
+from types import TracebackType
+from typing import Any, AsyncContextManager, List, Optional, Set, Tuple, Type, Union
 
 if sys.version_info >= (3, 7):
     from contextlib import AsyncExitStack
@@ -24,6 +25,7 @@ from yapapi.ctx import WorkContext
 from yapapi.engine import _Engine, Job
 from yapapi.payload import Payload
 from yapapi.props import NodeInfo
+from yapapi.rest.activity import CommandExecutionError, BatchTimeoutError
 
 
 logger = logging.getLogger(__name__)
@@ -67,6 +69,13 @@ class ServiceSignal:
     response_to: Optional["ServiceSignal"] = None
 
 
+# Return type for `sys.exc_info()`
+ExcInfo = Union[
+    Tuple[Type[BaseException], BaseException, TracebackType],
+    Tuple[None, None, None],
+]
+
+
 class Service:
     """Base class for service specifications.
 
@@ -87,6 +96,15 @@ class Service:
         self.__inqueue: asyncio.Queue[ServiceSignal] = asyncio.Queue()
         self.__outqueue: asyncio.Queue[ServiceSignal] = asyncio.Queue()
 
+        # Information on exception that caused the service change state,
+        # as returned by `sys.exc_info()`.
+        # Tuple of `None`'s means that the transition was not caused by an exception.
+        self._exc_info: ExcInfo = (None, None, None)
+
+        # TODO: maybe transition due to a control signal should also set this? To distinguish
+        # stopping the service externally (e.g., via `cluster.stop()`) from internal transition
+        # (e.g., via returning from `Service.run()`).
+
     @property
     def id(self):
         """Return the id of this service instance.
@@ -102,6 +120,10 @@ class Service:
 
     def __repr__(self):
         return f"<{self.__class__.__name__}: {self.id}>"
+
+    def exc_info(self) -> ExcInfo:
+        """Return exception info for an exception that caused the last state transition."""
+        return self._exc_info
 
     async def send_message(self, message: Any = None):
         """Send a control message to this instance."""
@@ -366,38 +388,72 @@ class Cluster(AsyncContextManager):
                 (batch_task, signal_task), return_when=asyncio.FIRST_COMPLETED
             )
 
+            def change_state(stop=False, exc_info=(None, None, None)):
+                """Initiate state transition, possibly due to an error."""
+
+                nonlocal batch_task, handler, instance
+
+                if not stop and exc_info == (None, None, None):
+                    # Normal, i.e. non-error, state transition
+                    instance.service_state.lifecycle()
+                else:
+                    # Transition due to an error or `ControlSignal.stop`
+                    # TODO: define this transition just like Service.lifecycle()?
+                    # isn't it the same as `(stop | terminate)()`?
+                    if instance.state == ServiceState.running:
+                        instance.service_state.stop()
+                    else:
+                        instance.service_state.terminate()
+
+                handler = self._get_handler(instance)
+                logger.debug("%s state changed to %s", instance.service, instance.state.value)
+                instance.service._exc_info = exc_info
+                if batch_task:
+                    batch_task.cancel()
+                    # TODO: await batch_task here?
+                batch_task = None
+
             if batch_task in done:
                 # Process a batch
                 try:
+                    # Errors in service code will be raised by `batch_task.result()`.
+                    # These include:
+                    # - StopAsyncIteration's resulting from normal exit from handler function
+                    # - CommandExecutionError's or BatchTimeout's that were thrown into
+                    #   the service code the `except (CommandExecutionError, ...)` clause below
                     batch = batch_task.result()
-                    fut_result = yield batch
-                    result = await fut_result
-                    wrapped_results = loop.create_future()
-                    wrapped_results.set_result(result)
-                    batch_task = loop.create_task(handler.asend(wrapped_results))
                 except StopAsyncIteration:
-                    instance.service_state.lifecycle()
-                    handler = None
-                    batch_task = None
+                    change_state()
+                except Exception:
+                    logger.warning("Unhandled exception in service", exc_info=True)
+                    change_state(exc_info=sys.exc_info())
+                else:
+                    try:
+                        # Errors in commands executed on provider will be raised here:
+                        fut_result = yield batch
+                    except (CommandExecutionError, BatchTimeoutError):
+                        # Throw the error into the service code so it can be handled there
+                        logger.warning("Command execution error", exc_info=True)
+                        batch_task = loop.create_task(handler.athrow(*sys.exc_info()))
+                    except Exception:
+                        # Could be an ApiException thrown in call_exec or get_exec_batch_results
+                        # operations of Activity API. Currently we do not pass such exceptions
+                        # to service handlers but initiate a state transition
+                        logger.error("Unhandled engine error", exc_info=True)
+                        change_state(exc_info=sys.exc_info())
+                    else:
+                        result = await fut_result
+                        wrapped_results = loop.create_future()
+                        wrapped_results.set_result(result)
+                        batch_task = loop.create_task(handler.asend(wrapped_results))
 
             if signal_task in done:
                 # Process a signal
                 ctl = signal_task.result()
                 logger.debug("Processing control signal %s", ctl)
                 if ctl == ControlSignal.stop:
-                    if instance.state == ServiceState.running:
-                        instance.service_state.stop()
-                    else:
-                        instance.service_state.terminate()
-                    handler = None
-                    if batch_task:
-                        batch_task.cancel()
-                        batch_task = None
+                    change_state(stop=True)
                 signal_task = None
-
-            if handler is None:
-                handler = self._get_handler(instance)
-                logger.debug("%s state changed to %s", instance.service, instance.state.value)
 
         logger.debug("No handler for %s in state %s", instance.service, instance.state.value)
 


### PR DESCRIPTION
Resolves #465 
Resolves #485 

Changes in this PR:
1. Errors raised during command execution (`CommandExecutionError` and `BatchTimeoutError`) are passed to service handlers (where they may be handled by service code, or not).
2. Errors raised in service handlers (these include errors mentioned in 1. that were then thrown into service handlers but were not caught there) initiate a state transition to `stopping` (from `running`) or `terminated` state (from states other than `running`).
3. Errors raised in the engine, other than mentioned in 1. (for example, `ApiException` raised by Activity API calls) *are not* passed to service handlers (we may want to change it in future, in this case we should also be doing the same in the `Executor`) but initiate a state transition right away.
4. A new attribute `Service._exc_info` (and method `Service.exc_info()`) returns a triple with information, in the format returned by `sys.exc_info()`, on the error that initiated the last state transition. This info can be used in service handlers e.g. to distinguish between stopping normally or due to errors.
5. Classes `CommandExecutionError` and `BatchTimeoutError` now have a common superclass `BatchError`. The idea is to group there all exception classes related to execution of commands on providers that are propagated to user code (so for example, `ApiException`s raised when making Activity API calls do not belong there, because they're not propagated to user code).