### PR TITLE
Update ya-aioclient from ^0.5 to ^0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ colorama = "^0.4.4"
 # It will be then installable with `poetry install -E integration-tests`.
 # Note that putting `goth` in `poetry.dev-dependencies` instead of `poetry.dependencies`
 # would not work: see https://github.com/python-poetry/poetry/issues/129.
-# goth = { version = "^0.5", optional = true, python = "^3.8.0" }
-goth = { git = "https://github.com/golemfactory/goth.git", branch = "az/ya-aioclient-0.6", optional = true, python = "^3.8.0", develop = true }
+goth = { version = "^0.6", optional = true, python = "^3.8.0" }
+# goth = { git = "https://github.com/golemfactory/goth.git", branch = "your-branch-name", optional = true, python = "^3.8.0", develop = true }
 Deprecated = "^1.2.12"
 python-statemachine = "^0.8.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ rich = { version = "^10.2", optional = true }
 async_exit_stack = "^1.0.1"
 jsonrpc-base = "^1.0.3"
 
-ya-aioclient = "^0.5.1"
+ya-aioclient = "^0.6"
 toml = "^0.10.1"
 srvresolver = "^0.3.5"
 colorama = "^0.4.4"
@@ -44,7 +44,8 @@ colorama = "^0.4.4"
 # It will be then installable with `poetry install -E integration-tests`.
 # Note that putting `goth` in `poetry.dev-dependencies` instead of `poetry.dependencies`
 # would not work: see https://github.com/python-poetry/poetry/issues/129.
-goth = { version = "^0.5", optional = true, python = "^3.8.0" }
+# goth = { version = "^0.5", optional = true, python = "^3.8.0" }
+goth = { git = "https://github.com/golemfactory/goth.git", branch = "az/ya-aioclient-0.6", optional = true, python = "^3.8.0", develop = true }
 Deprecated = "^1.2.12"
 python-statemachine = "^0.8.0"
 

--- a/yapapi/rest/payment.py
+++ b/yapapi/rest/payment.py
@@ -145,6 +145,7 @@ class Payment(object):
                 total_amount=str(amount),
                 timeout=allocation_timeout,
                 make_deposit=make_deposit,
+                timestamp=datetime.now(timezone.utc),
                 # TODO: fix this
                 spent_amount="",
                 remaining_amount="",


### PR DESCRIPTION
- [x] Update `ya-aioclient` from `^0.5` to `^0.6` in `goth` (https://github.com/golemfactory/goth/pull/515)
- [x] Release `goth-0.6.0`
- [x] Update `goth` dependency in `yapapi` from `^0.5` to `^0.6` (this correspondence between version numbers in `ya-aioclient` and `goth` is a coincidence)