### PR TITLE
Respawn instances that failed in `starting` state

### DIFF
--- a/tests/goth/test_instance_restart/requestor.py
+++ b/tests/goth/test_instance_restart/requestor.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""A simple requestor that creates a cluster with a single service instance.
+
+The service is designed so that the first instance created (and only the first one)
+sends an error command in its `start()` method which results in the instance's
+termination before going to the `running` state.
+"""
+import asyncio
+from datetime import datetime, timedelta
+import pathlib
+import sys
+from types import TracebackType
+from typing import Optional, Type
+
+from yapapi import Golem
+from yapapi.rest.activity import CommandExecutionError, BatchTimeoutError
+from yapapi.services import Service
+
+from yapapi.log import enable_default_logger, log_summary, log_event_repr, pluralize  # noqa
+from yapapi.payload import vm
+
+
+instances_started = 0
+instances_running = 0
+
+
+class FirstInstanceFailsToStart(Service):
+    @staticmethod
+    async def get_payload():
+        return await vm.repo(
+            image_hash="8b11df59f84358d47fc6776d0bb7290b0054c15ded2d6f54cf634488",
+            min_mem_gib=0.5,
+            min_storage_gib=2.0,
+        )
+
+    async def start(self):
+
+        global instances_started
+        instances_started += 1
+
+        await asyncio.sleep(1)
+
+        if instances_started == 1:
+            self._ctx.run("/no/such/command")
+        else:
+            self._ctx.run("/bin/echo", "STARTING")
+        future_results = yield self._ctx.commit()
+        results = await future_results
+        print(f"{results[-1].stdout.strip()}")
+
+    async def run(self):
+
+        global instances_running
+        instances_running += 1
+
+        await asyncio.sleep(1)
+        self._ctx.run("/bin/echo", "RUNNING")
+        future_results = yield self._ctx.commit()
+        results = await future_results
+        print(f"{results[-1].stdout.strip()}")
+
+
+async def main():
+
+    async with Golem(budget=1.0, subnet_tag="goth") as golem:
+
+        print("Starting cluster...")
+        await golem.run_service(FirstInstanceFailsToStart)
+
+        while not instances_running:
+            print("Waiting for an instance...")
+            await asyncio.sleep(5)
+
+
+if __name__ == "__main__":
+
+    enable_default_logger(
+        log_file=f"test-instance-restart-{now}.log",
+        debug_activity_api=True,
+        debug_market_api=True,
+        debug_payment_api=True,
+    )
+
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(main())
+    loop.run_until_complete(task)

--- a/tests/goth/test_instance_restart/test_instance_restart.py
+++ b/tests/goth/test_instance_restart/test_instance_restart.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Test if a Cluster respawns an instance if an existing instance fails in the `starting` state."""
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+import goth.configuration
+from goth.runner import Runner
+from goth.runner.log import configure_logging
+from goth.runner.probe import RequestorProbe
+
+logger = logging.getLogger("goth.test.async_task_generation")
+
+
+@pytest.mark.asyncio
+async def test_instance_restart(project_dir: Path, log_dir: Path, config_overrides) -> None:
+    """Run the `requestor.py` and make sure that it's standard output is as expected."""
+
+    configure_logging(log_dir)
+
+    # Override the default test configuration to create only one provider node
+    nodes = [
+        {"name": "requestor", "type": "Requestor"},
+        {"name": "provider-1", "type": "VM-Wasm-Provider", "use-proxy": True},
+    ]
+    config_overrides.append(("nodes", nodes))
+    goth_config = goth.configuration.load_yaml(
+        project_dir / "tests" / "goth" / "assets" / "goth-config.yml",
+        config_overrides,
+    )
+
+    runner = Runner(base_log_dir=log_dir, compose_config=goth_config.compose_config)
+
+    async with runner(goth_config.containers):
+
+        requestor = runner.get_probes(probe_type=RequestorProbe)[0]
+
+        async with requestor.run_command_on_host(
+            str(Path(__file__).parent / "requestor.py"), env=os.environ
+        ) as (_cmd_task, cmd_monitor):
+
+            # The first attempt to create an instance should fail
+            await cmd_monitor.wait_for_pattern(
+                ".*INFO yapapi\.services\] .* comissioned$", timeout=60
+            )
+            await cmd_monitor.wait_for_pattern(".*CommandExecutionError", timeout=20)
+            await cmd_monitor.wait_for_pattern(
+                ".*INFO yapapi\.services\] .* decomissioned$", timeout=20
+            )
+            # The second one should succeed
+            await cmd_monitor.wait_for_pattern(
+                ".*INFO yapapi\.services\] .* comissioned$", timeout=30
+            )
+            await cmd_monitor.wait_for_pattern("STARTING$", timeout=20)
+            await cmd_monitor.wait_for_pattern("RUNNING$", timeout=20)
+            await cmd_monitor.wait_for_pattern(
+                ".*INFO yapapi\.services\] .* decomissioned$", timeout=20
+            )

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -126,6 +126,7 @@ class Golem(_Engine):
         num_instances: int = 1,
         payload: Optional[Payload] = None,
         expiration: Optional[datetime] = None,
+        respawn_unstarted_instances=True,
     ) -> Cluster:
         """Run a number of instances of a service represented by a given `Service` subclass.
 
@@ -135,6 +136,8 @@ class Golem(_Engine):
         :param payload: optional runtime definition for the service; if not provided, the
             payload specified by the `get_payload()` method of `service_class` is used
         :param expiration: optional expiration datetime for the service
+        :param respawn_unstarted_instances: if an instance fails in the `starting` state, should
+            the returned Cluster try to spawn another instance
         :return: a `Cluster` of service instances
 
         example usage:
@@ -202,6 +205,7 @@ class Golem(_Engine):
             payload=payload,
             num_instances=num_instances,
             expiration=expiration,
+            respawn_unstarted_instances=respawn_unstarted_instances,
         )
         await self._stack.enter_async_context(cluster)
         cluster.spawn_instances()

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -55,10 +55,21 @@ class ServiceState(statemachine.StateMachine):
     terminate = terminated.from_(starting, running, stopping, terminated)
     mark_unresponsive = unresponsive.from_(starting, running, stopping, terminated)
 
+    # transition performed when handler for the current state terminates normally,
+    # that is, not due to an error or `ControlSignal.stop`
     lifecycle = ready | stop | terminate
+
+    # transition performed on error or `ControlSignal.stop`
+    error_or_stop = stop | terminate
 
     # just a helper set of states in which the service can be interacted-with
     AVAILABLE = (starting, running, stopping)
+
+    instance: "ServiceInstance"
+
+    def on_enter_state(self, state: statemachine.State):
+        """Register `state` in the instance's list of visited states."""
+        self.instance.visited_states.append(state)
 
 
 @dataclass
@@ -224,11 +235,20 @@ class ServiceInstance:
     service: Service
     control_queue: "asyncio.Queue[ControlSignal]" = field(default_factory=asyncio.Queue)
     service_state: ServiceState = field(default_factory=ServiceState)
+    visited_states: List[ServiceState] = field(default_factory=list)
+
+    def __post_init__(self):
+        self.service_state.instance = self
 
     @property
     def state(self) -> ServiceState:
         """Return the current state of this instance."""
         return self.service_state.current_state
+
+    @property
+    def started_successfully(self) -> bool:
+        """Return `True` if this instance has entered `running` state, `False` otherwise."""
+        return ServiceState.running in self.visited_states
 
 
 class Cluster(AsyncContextManager):
@@ -241,6 +261,7 @@ class Cluster(AsyncContextManager):
         payload: Payload,
         num_instances: int = 1,
         expiration: Optional[datetime] = None,
+        respawn_unstarted_instances: bool = True,
     ):
         """Initialize this Cluster.
 
@@ -250,6 +271,8 @@ class Cluster(AsyncContextManager):
         :param num_instances: number of instances to spawn in this Cluster
         :param expiration: a date before which all agreements related to running services
             in this Cluster should be terminated
+        :param respawn_unstarted_instances: if an instance fails in the `starting` state,
+            should this Cluster try to spawn another instance
         """
 
         self.id = str(next(cluster_ids))
@@ -261,6 +284,7 @@ class Cluster(AsyncContextManager):
         self._expiration = expiration or datetime.now(timezone.utc) + DEFAULT_SERVICE_EXPIRATION
         self._task_ids = itertools.count(1)
         self._stack = AsyncExitStack()
+        self._respawn_unstarted_instances = respawn_unstarted_instances
 
         self.__instances: List[ServiceInstance] = []
         """List of Service instances"""
@@ -383,13 +407,8 @@ class Cluster(AsyncContextManager):
             # Normal, i.e. non-error, state transition
             instance.service_state.lifecycle()
         elif isinstance(event, tuple) or event == ControlSignal.stop:
-            # Transition due to an error or `stop` signal
-            # TODO: define this transition just like Service.lifecycle()?
-            # isn't it the same as `(stop | terminate)()`?
-            if instance.state == ServiceState.running:
-                instance.service_state.stop()
-            else:
-                instance.service_state.terminate()
+            # Transition on error or `stop` signal
+            instance.service_state.error_or_stop()
         else:
             # Unhandled signal, don't change the state
             assert isinstance(event, ControlSignal)
@@ -399,10 +418,9 @@ class Cluster(AsyncContextManager):
             instance.service._exc_info = event
         return instance.state != prev_state
 
-    async def _run_instance(self, ctx: WorkContext):
+    async def _run_instance(self, instance: ServiceInstance):
 
         loop = asyncio.get_event_loop()
-        instance = ServiceInstance(service=self._service_class(self, ctx))
         self.__instances.append(instance)
 
         logger.info("%s commissioned", instance.service)
@@ -496,21 +514,26 @@ class Cluster(AsyncContextManager):
         logger.info("%s decomissioned", instance.service)
 
     async def spawn_instance(self) -> None:
-        """Spawn a new service instance within this Cluster."""
+        """Spawn a new service instance within this Cluster.
+
+        :param respawn_on_failure: if a new instance fails in `starting` state,
+            whether to spawn another instance instead.
+        """
 
         logger.debug("spawning instance within %s", self)
-        spawned = False
+        instance: Optional[ServiceInstance] = None
         agreement_id: Optional[str]  # set in start_worker
 
         async def start_worker(agreement: rest.market.Agreement, node_info: NodeInfo) -> None:
 
-            nonlocal agreement_id, spawned
+            nonlocal agreement_id, instance
 
             agreement_id = agreement.id
             self.emit(events.WorkerStarted(agr_id=agreement.id))
 
             try:
                 act = await self._engine.create_activity(agreement.id)
+                self.emit(events.ActivityCreated(act_id=act.id, agr_id=agreement.id))
             except Exception:
                 self.emit(
                     events.ActivityCreateFailed(
@@ -520,13 +543,14 @@ class Cluster(AsyncContextManager):
                 raise
 
             async with act:
-                spawned = True
-                self.emit(events.ActivityCreated(act_id=act.id, agr_id=agreement.id))
 
                 self._engine.accept_debit_notes_for_agreement(agreement.id)
+
                 work_context = WorkContext(
                     act.id, node_info, self._engine.storage_manager, emitter=self.emit
                 )
+                instance = ServiceInstance(service=self._service_class(self, work_context))
+
                 task_id = f"{self.id}:{next(self._task_ids)}"
                 self.emit(
                     events.TaskStarted(
@@ -537,7 +561,7 @@ class Cluster(AsyncContextManager):
                 )
 
                 try:
-                    instance_batches = self._run_instance(work_context)
+                    instance_batches = self._run_instance(instance)
                     try:
                         await self._engine.process_batches(agreement.id, act, instance_batches)
                     except StopAsyncIteration:
@@ -558,7 +582,7 @@ class Cluster(AsyncContextManager):
 
         loop = asyncio.get_event_loop()
 
-        while not spawned:
+        while instance is None:
             agreement_id = None
             await asyncio.sleep(1.0)
             task = await self._job.agreements_pool.use_agreement(
@@ -568,6 +592,13 @@ class Cluster(AsyncContextManager):
                 continue
             try:
                 await task
+                if (
+                    instance
+                    and not instance.started_successfully
+                    and self._respawn_unstarted_instances
+                ):
+                    logger.warning("Instance failed when starting, trying to create another one...")
+                    instance = None
             except Exception:
                 if agreement_id:
                     self.emit(events.WorkerFinished(agr_id=agreement_id, exc_info=sys.exc_info()))


### PR DESCRIPTION
Resolves #392 

This PR makes `Cluster` spawn a **new** instance, if previously created instance fails in `starting` state. If an instance reaches its `running` state and then fails, no new instance will be spawned.

Re-spawning instances can be suppressed -- for a whole`Cluster` -- by passing `respawn_unstarted_instances=False` in a call to `Golem.run_service()` that creates the `Cluster`.
