### PR TITLE
enable parametrization of Service instances within a single `Golem.run_service()` call

### DIFF
--- a/examples/simple-service-poc/simple_service.py
+++ b/examples/simple-service-poc/simple_service.py
@@ -32,13 +32,16 @@ from utils import (
     TEXT_COLOR_YELLOW,
 )
 
-NUM_INSTANCES = 1
 STARTING_TIMEOUT = timedelta(minutes=4)
 
 
 class SimpleService(Service):
     SIMPLE_SERVICE = "/golem/run/simple_service.py"
     SIMPLE_SERVICE_CTL = "/golem/run/simulate_observations_ctl.py"
+
+    def __init__(self, *args, instance_name, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = instance_name
 
     @staticmethod
     async def get_payload():
@@ -84,7 +87,7 @@ class SimpleService(Service):
         yield self._ctx.commit()
 
 
-async def main(subnet_tag, driver=None, network=None):
+async def main(subnet_tag, driver=None, network=None, num_instances=1):
     async with Golem(
         budget=1.0,
         subnet_tag=subnet_tag,
@@ -102,27 +105,29 @@ async def main(subnet_tag, driver=None, network=None):
         commissioning_time = datetime.now()
 
         print(
-            f"{TEXT_COLOR_YELLOW}starting {pluralize(NUM_INSTANCES, 'instance')}{TEXT_COLOR_DEFAULT}"
+            f"{TEXT_COLOR_YELLOW}starting {pluralize(num_instances, 'instance')}{TEXT_COLOR_DEFAULT}"
         )
 
         # start the service
 
         cluster = await golem.run_service(
             SimpleService,
-            num_instances=NUM_INSTANCES,
+            instance_params=[
+                {"instance_name": f"simple-service-{i+1}"} for i in range(num_instances)
+            ],
             expiration=datetime.now(timezone.utc) + timedelta(minutes=120),
         )
 
         # helper functions to display / filter instances
 
         def instances():
-            return [(s.provider_name, s.state.value) for s in cluster.instances]
+            return [f"{s.name}: {s.state.value} on {s.provider_name}" for s in cluster.instances]
 
         def still_running():
             return any([s for s in cluster.instances if s.is_available])
 
         def still_starting():
-            return len(cluster.instances) < NUM_INSTANCES or any(
+            return len(cluster.instances) < num_instances or any(
                 [s for s in cluster.instances if s.state == ServiceState.starting]
             )
 
@@ -163,6 +168,7 @@ if __name__ == "__main__":
     parser = build_parser(
         "A very simple / POC example of a service running on Golem, utilizing the VM runtime"
     )
+    parser.add_argument("--num-instances", type=int, default=1)
     now = datetime.now().strftime("%Y-%m-%d_%H.%M.%S")
     parser.set_defaults(log_file=f"simple-service-yapapi-{now}.log")
     args = parser.parse_args()
@@ -179,7 +185,7 @@ if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
     task = loop.create_task(
-        main(subnet_tag=args.subnet_tag, driver=args.driver, network=args.network)
+        main(subnet_tag=args.subnet_tag, driver=args.driver, network=args.network, num_instances=args.num_instances)
     )
 
     try:

--- a/examples/simple-service-poc/simple_service.py
+++ b/examples/simple-service-poc/simple_service.py
@@ -185,7 +185,12 @@ if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
     task = loop.create_task(
-        main(subnet_tag=args.subnet_tag, driver=args.driver, network=args.network, num_instances=args.num_instances)
+        main(
+            subnet_tag=args.subnet_tag,
+            driver=args.driver,
+            network=args.network,
+            num_instances=args.num_instances,
+        )
     )
 
     try:

--- a/tests/services/test_cluster.py
+++ b/tests/services/test_cluster.py
@@ -1,0 +1,71 @@
+import itertools
+import pytest
+from unittest.mock import Mock, patch, call
+from yapapi.services import Cluster, Service, ServiceError
+
+
+class _TestService(Service):
+    pass
+
+
+def _get_cluster():
+    return Cluster(engine=Mock(), service_class=_TestService, payload=Mock())
+
+
+@pytest.mark.parametrize(
+    "kwargs, calls, error",
+    [
+        (
+            {"num_instances": 1},
+            [call({})],
+            None,
+        ),
+        (
+            {"num_instances": 3},
+            [call({}) for _ in range(3)],
+            None,
+        ),
+        (
+            {"instance_params": [{}]},
+            [call({})],
+            None,
+        ),
+        (
+            {"instance_params": [{"n": 1}, {"n": 2}]},
+            [call({"n": 1}), call({"n": 2})],
+            None,
+        ),
+        (
+            # num_instances takes precedence
+            {"num_instances": 2, "instance_params": [{} for _ in range(3)]},
+            [call({}), call({})],
+            None,
+        ),
+        (
+            # num_instances takes precedence
+            {"num_instances": 3, "instance_params": ({"n": i} for i in itertools.count(1))},
+            [call({"n": 1}), call({"n": 2}), call({"n": 3})],
+            None,
+        ),
+        (
+            # num_instances takes precedence
+            {"num_instances": 4, "instance_params": [{} for _ in range(3)]},
+            [call({}) for _ in range(3)],
+            "`instance_params` iterable depleted after 3 spawned instances.",
+        ),
+    ]
+)
+def test_spawn_instances(kwargs, calls, error):
+    with patch("yapapi.services.Cluster.spawn_instance") as spawn_instance:
+        cluster = _get_cluster()
+        try:
+            cluster.spawn_instances(**kwargs)
+        except ServiceError as e:
+            if error is not None:
+                assert str(e) == error
+            else:
+                assert False, e
+        else:
+            assert error is None, f"Expected ServiceError: {error}"
+
+    assert spawn_instance.mock_calls == calls

--- a/tests/services/test_cluster.py
+++ b/tests/services/test_cluster.py
@@ -53,7 +53,7 @@ def _get_cluster():
             [call({}) for _ in range(3)],
             "`instance_params` iterable depleted after 3 spawned instances.",
         ),
-    ]
+    ],
 )
 def test_spawn_instances(kwargs, calls, error):
     with patch("yapapi.services.Cluster.spawn_instance") as spawn_instance:

--- a/tests/services/test_cluster.py
+++ b/tests/services/test_cluster.py
@@ -1,6 +1,6 @@
 import itertools
 import pytest
-from unittest.mock import Mock, patch, call
+from unittest.mock import Mock, patch, call, AsyncMock
 from yapapi.services import Cluster, Service, ServiceError
 
 
@@ -55,10 +55,9 @@ def _get_cluster():
         ),
     ],
 )
-def test_spawn_instances(kwargs, calls, error):
-    with patch("yapapi.services.Cluster.spawn_instance") as spawn_instance, patch(
-        "yapapi.services.asyncio.get_event_loop", Mock()
-    ):
+@pytest.mark.asyncio
+async def test_spawn_instances(kwargs, calls, error):
+    with patch("yapapi.services.Cluster.spawn_instance", AsyncMock()) as spawn_instance:
         cluster = _get_cluster()
         try:
             cluster.spawn_instances(**kwargs)

--- a/tests/services/test_cluster.py
+++ b/tests/services/test_cluster.py
@@ -54,6 +54,11 @@ def _get_cluster():
             [call({}) for _ in range(3)],
             "`instance_params` iterable depleted after 3 spawned instances.",
         ),
+        (
+            {"num_instances": 0},
+            [],
+            None,
+        ),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/services/test_cluster.py
+++ b/tests/services/test_cluster.py
@@ -56,7 +56,8 @@ def _get_cluster():
     ],
 )
 def test_spawn_instances(kwargs, calls, error):
-    with patch("yapapi.services.Cluster.spawn_instance") as spawn_instance:
+    with patch("yapapi.services.Cluster.spawn_instance") as spawn_instance, \
+            patch("yapapi.services.asyncio.get_event_loop", Mock()):
         cluster = _get_cluster()
         try:
             cluster.spawn_instances(**kwargs)

--- a/tests/services/test_cluster.py
+++ b/tests/services/test_cluster.py
@@ -56,8 +56,9 @@ def _get_cluster():
     ],
 )
 def test_spawn_instances(kwargs, calls, error):
-    with patch("yapapi.services.Cluster.spawn_instance") as spawn_instance, \
-            patch("yapapi.services.asyncio.get_event_loop", Mock()):
+    with patch("yapapi.services.Cluster.spawn_instance") as spawn_instance, patch(
+        "yapapi.services.asyncio.get_event_loop", Mock()
+    ):
         cluster = _get_cluster()
         try:
             cluster.spawn_instances(**kwargs)

--- a/tests/services/test_cluster.py
+++ b/tests/services/test_cluster.py
@@ -1,6 +1,7 @@
 import itertools
+import sys
 import pytest
-from unittest.mock import Mock, patch, call, AsyncMock
+from unittest.mock import Mock, patch, call
 from yapapi.services import Cluster, Service, ServiceError
 
 
@@ -56,8 +57,9 @@ def _get_cluster():
     ],
 )
 @pytest.mark.asyncio
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="AsyncMock requires python 3.8+")
 async def test_spawn_instances(kwargs, calls, error):
-    with patch("yapapi.services.Cluster.spawn_instance", AsyncMock()) as spawn_instance:
+    with patch("yapapi.services.Cluster.spawn_instance") as spawn_instance:
         cluster = _get_cluster()
         try:
             cluster.spawn_instances(**kwargs)

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -131,9 +131,9 @@ class Golem(_Engine):
         """Run a number of instances of a service represented by a given `Service` subclass.
 
         :param service_class: a subclass of `Service` that represents the service to be run
-        :param num_instances: optional number of service instances to run, defaults to a single
+        :param num_instances: optional number of service instances to run. Defaults to a single
             instance, unless `instance_params` is given, in which case, the Cluster will be created
-            with as many instances as there are elements in the `instance_params` iterable
+            with as many instances as there are elements in the `instance_params` iterable.
         :param instance_params: optional list of dictionaries of keyword arguments that will be passed
             to consecutive, spawned instances. The number of elements in the iterable determines the
             number of instances spawned, unless `num_instances` is given, in which case the latter takes

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -123,7 +123,8 @@ class Golem(_Engine):
     async def run_service(
         self,
         service_class: Type[Service],
-        num_instances: int = 1,
+        num_instances: Optional[int] = None,
+        instance_params: Optional[Iterable[Dict]] = None,
         payload: Optional[Payload] = None,
         expiration: Optional[datetime] = None,
     ) -> Cluster:
@@ -131,7 +132,16 @@ class Golem(_Engine):
 
         :param service_class: a subclass of `Service` that represents the service to be run
         :param num_instances: optional number of service instances to run, defaults to a single
-            instance
+            instance, unless `instance_params` is given, in which case, the Cluster will be created
+            with as many instances as there are elements in the `instance_params` iterable
+        :param instance_params: optional list of dictionaries of keyword arguments that will be passed
+            to consecutive, spawned instances. The number of elements in the iterable determines the
+            number of instances spawned, unless `num_instances` is given, in which case the latter takes
+            precedence.
+            In other words, if both `num_instances` and `instance_params` are provided,
+            the Cluster will be created with the number of instances determined by `num_instances`
+            and if there are too few elements in the `instance_params` iterable, it will results in
+            an error.
         :param payload: optional runtime definition for the service; if not provided, the
             payload specified by the `get_payload()` method of `service_class` is used
         :param expiration: optional expiration datetime for the service
@@ -200,9 +210,8 @@ class Golem(_Engine):
             engine=self,
             service_class=service_class,
             payload=payload,
-            num_instances=num_instances,
             expiration=expiration,
         )
         await self._stack.enter_async_context(cluster)
-        cluster.spawn_instances()
+        cluster.spawn_instances(num_instances=num_instances, instance_params=instance_params)
         return cluster

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -134,6 +134,8 @@ class Golem(_Engine):
         :param num_instances: optional number of service instances to run. Defaults to a single
             instance, unless `instance_params` is given, in which case, the Cluster will be created
             with as many instances as there are elements in the `instance_params` iterable.
+            if `num_instances` is set to < 1, the `Cluster` will still be created but no instances
+            will be spawned within it.
         :param instance_params: optional list of dictionaries of keyword arguments that will be passed
             to consecutive, spawned instances. The number of elements in the iterable determines the
             number of instances spawned, unless `num_instances` is given, in which case the latter takes

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -503,7 +503,7 @@ class Cluster(AsyncContextManager):
 
         # convert the parameters iterable to an iterator
         # if not provided, make a default iterator consisting of empty dictionaries
-        instance_params = iter(instance_params or (dict() for _ in range(num_instances)))
+        instance_params = iter(instance_params or (dict() for _ in range(num_instances)))  # type: ignore
 
         loop = asyncio.get_event_loop()
         spawned_instances = 0

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -478,9 +478,9 @@ class Cluster(AsyncContextManager):
         instance.control_queue.put_nowait(ControlSignal.stop)
 
     def spawn_instances(
-            self,
-            num_instances: Optional[int] = None,
-            instance_params: Optional[Iterable[Dict]] = None,
+        self,
+        num_instances: Optional[int] = None,
+        instance_params: Optional[Iterable[Dict]] = None,
     ) -> None:
         """Spawn new instances within this Cluster.
 

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -567,6 +567,7 @@ class Cluster(AsyncContextManager):
         :param num_instances: optional number of service instances to run. Defaults to a single
             instance, unless `instance_params` is given, in which case, the Cluster will spawn
             as many instances as there are elements in the `instance_params` iterable.
+            if `num_instances` is not None and < 1, the method will immediately return and log a warning.
         :param instance_params: optional list of dictionaries of keyword arguments that will be passed
             to consecutive, spawned instances. The number of elements in the iterable determines the
             number of instances spawned, unless `num_instances` is given, in which case the latter takes
@@ -576,6 +577,12 @@ class Cluster(AsyncContextManager):
             too few elements in the `instance_params` iterable, it will results in an error.
 
         """
+        # just a sanity check
+        if num_instances is not None and num_instances < 1:
+            logger.warning(
+                "Trying to spawn less than one instance. num_instances: %s", num_instances
+            )
+            return
 
         # if the parameters iterable was not given, assume a default of a single instance
         if not num_instances and not instance_params:

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -484,9 +484,9 @@ class Cluster(AsyncContextManager):
     ) -> None:
         """Spawn new instances within this Cluster.
 
-        :param num_instances: optional number of service instances to run, defaults to a single
+        :param num_instances: optional number of service instances to run. Defaults to a single
             instance, unless `instance_params` is given, in which case, the Cluster will spawn
-            as many instances as there are elements in the `instance_params` iterable
+            as many instances as there are elements in the `instance_params` iterable.
         :param instance_params: optional list of dictionaries of keyword arguments that will be passed
             to consecutive, spawned instances. The number of elements in the iterable determines the
             number of instances spawned, unless `num_instances` is given, in which case the latter takes


### PR DESCRIPTION
enable parametrization of Service instances within a single `Golem.run_service()` call

+ use of service parametrization in `simple-service-poc`

closes #372 