### PR TITLE
Handle errors raised in batch.prepare() in process_batches()

### DIFF
--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -520,11 +520,10 @@ class _Engine(AsyncContextManager):
                 else None
             )
 
-            await batch.prepare()
             cc = CommandContainer()
-            batch.register(cc)
-
             try:
+                await batch.prepare()
+                batch.register(cc)
                 remote = await activity.send(cc.commands(), deadline=batch_deadline)
             except Exception:
                 item = await command_generator.athrow(*sys.exc_info())


### PR DESCRIPTION
Certain errors can be raised in a call to `batch.prepare()`, for example errors originating in `yapapi`'s `gftp` storage driver.

Such errors should be caught in `Golem.process_batches()` and thrown into a command generator, especially in Services API (a *command generator* in this case is `Cluster._run_instance()`). Otherwise, a service instance would become detached from the handler function and stuck in the state in which the error occurred -- this happens in issue #519.