### PR TITLE
add imports and a path to make low-level-api example runnable

### DIFF
--- a/examples/low-level-api/list-offers.py
+++ b/examples/low-level-api/list-offers.py
@@ -17,7 +17,6 @@ sys.path.append(str(examples_dir))
 import utils
 
 
-
 async def list_offers(conf: Configuration, subnet_tag: str):
     async with conf.market() as client:
         market_api = Market(client)

--- a/examples/low-level-api/list-offers.py
+++ b/examples/low-level-api/list-offers.py
@@ -6,6 +6,7 @@ import json
 import sys
 import pathlib
 
+
 from yapapi import props as yp
 from yapapi.log import enable_default_logger
 from yapapi.props.builder import DemandBuilder

--- a/examples/low-level-api/list-offers.py
+++ b/examples/low-level-api/list-offers.py
@@ -4,13 +4,17 @@ from asyncio import TimeoutError
 from datetime import datetime, timezone
 import json
 import sys
+import pathlib
 
 from yapapi import props as yp
 from yapapi.log import enable_default_logger
 from yapapi.props.builder import DemandBuilder
 from yapapi.rest import Configuration, Market, Activity, Payment  # noqa
 
-from examples import utils
+examples_dir = pathlib.Path(__file__).resolve().parent.parent
+sys.path.append(str(examples_dir))
+import utils
+
 
 
 async def list_offers(conf: Configuration, subnet_tag: str):


### PR DESCRIPTION
resolves issue #541 

examples/low-level-api/list-offers.py has been changed to accomplish the following so that it will run:

importing pathlib
adding examples_dir to the search path
importing utils in examples_dir
tested on linux
yapapi 0.6.2
yagna 0.7.2