### PR TITLE
Delete unused temp files and close unpublished files in GftpStorageProvider

### DIFF
--- a/tests/storage/test_gftp.py
+++ b/tests/storage/test_gftp.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from pathlib import Path
 import random
 import tempfile
-from typing import cast, List, Optional
+from typing import cast, List
 
 import pytest
 

--- a/tests/storage/test_gftp.py
+++ b/tests/storage/test_gftp.py
@@ -12,7 +12,7 @@ from yapapi.storage import gftp
 
 @pytest.fixture(scope="function")
 def test_dir():
-    """Creates a temporary directory containing test files.
+    """Create a temporary directory containing test files.
 
     The directory contains files `a_0.txt`, `a_1.txt` and `a_2.txt`
     containing the text `a`, and similarly with `b`, `c` and `d`.
@@ -40,7 +40,7 @@ def test_dir():
 
 @pytest.fixture(scope="function")
 def temp_dir():
-    """Creates a temporary directory for temporary files.
+    """Create a directory for temporary files.
 
     On exit asserts that the directory is empty.
     """
@@ -53,7 +53,15 @@ def temp_dir():
 
 
 class MockService(gftp.GftpDriver):
-    """A mock for a `gftp service` command."""
+    """A mock for the `gftp service` command.
+
+    To be used as a replacement for the real command in `yapapi.storage.gftp.GftpProvider`.
+
+    As with the real `gftp service` command, URL returned by `MockService.publish(file)`
+    is based on file's contents: files with the same content will have the same URL.
+    In case of this mock implementation, the URL is simply the contents of the file,
+    stripped from whitespaces.
+    """
 
     def __init__(self):
         self.published = defaultdict(list)

--- a/tests/storage/test_gftp.py
+++ b/tests/storage/test_gftp.py
@@ -1,10 +1,176 @@
 import asyncio
+from collections import defaultdict
 from pathlib import Path
-from tempfile import TemporaryDirectory
+import random
+import tempfile
+from typing import cast, List, Optional
 
 import pytest
 
 from yapapi.storage import gftp
+
+
+@pytest.fixture(scope="function")
+def test_dir():
+    """Creates a temporary directory containing test files.
+
+    The directory contains files `a_0.txt`, `a_1.txt` and `a_2.txt`
+    containing the text `a`, and similarly with `b`, `c` and `d`.
+
+    On exit asserts that no files were added to, or removed from,
+    the directory.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+
+        try:
+            test_files = set()
+            dir_path = Path(tmpdir)
+            for s in ("a", "b", "c", "d"):
+                for n in range(3):
+                    with open(dir_path / f"{s}_{n}.txt", "w") as f:
+                        f.write(f"{s}\n")
+                        test_files.add(Path(f.name))
+
+            yield dir_path
+
+        finally:
+            files = set(dir_path.glob("*"))
+            assert files == test_files
+
+
+@pytest.fixture(scope="function")
+def temp_dir():
+    """Creates a temporary directory for temporary files.
+
+    On exit asserts that the directory is empty.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            yield tmpdir
+        finally:
+            files = list(Path(tmpdir).glob("*"))
+            assert files == []
+
+
+class MockService(gftp.GftpDriver):
+    """A mock for a `gftp service` command."""
+
+    def __init__(self):
+        self.published = defaultdict(list)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        pass
+
+    async def version(self) -> str:
+        return "0.0.0"
+
+    async def publish(self, *, files: List[str]) -> List[gftp.PubLink]:
+        links = []
+        for f in files:
+            url = Path(f).read_text().strip()
+            links.append(gftp.PubLink(file=f, url=url))
+            self.published[url].append(Path(f))
+        return links
+
+    async def close(self, *, urls: List[str]) -> List[gftp.CommandStatus]:
+        statuses = cast(List[gftp.CommandStatus], [])
+        for u in urls:
+            if u in self.published:
+                del self.published[u]
+                statuses.append("ok")
+            else:
+                statuses.append("error")
+        return statuses
+
+    def opened_file(self, url: str) -> Optional[Path]:
+        return self.published[url][-1] if url in self.published else None
+
+
+@pytest.fixture(scope="function")
+def mock_service(monkeypatch):
+
+    service = MockService()
+    monkeypatch.setattr(gftp, "service", lambda _debug: service)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_gftp_provider(test_dir, temp_dir, mock_service):
+    """Simulate a number of workers concurrently uploading files and bytes."""
+
+    num_batches = 20
+    num_workers = 5
+
+    file_uploads = 0
+    byte_uploads = 0
+
+    async def worker(id: int, provider: gftp.GftpProvider):
+        """A test worker."""
+
+        nonlocal num_batches, temp_dir, file_uploads, byte_uploads
+
+        for n in range(1, num_batches + 1):
+            print(f"Worker {id}, batch {n}/{num_batches}")
+
+            sources: List[gftp.GftpSource] = []
+
+            # simulate prepare() for ctx.send_file and ctx.send_bytes/send_json
+            while True:
+                r = random.randint(1, 5)
+
+                if r == 1:
+                    # upload a file
+                    a = random.choice(["a", "b", "c", "d"])
+                    path = test_dir / f"{a}_0.txt"
+                    src = await provider.upload_file(path)
+                    assert isinstance(src, gftp.GftpSource)
+                    sources.append(src)
+                    file_uploads += 1
+
+                elif r in (2, 3, 4):
+                    # upload a stream
+                    a = random.choice(["a", "b", "c", "d"])
+                    src = await provider.upload_bytes(a.encode("utf-8"))
+                    assert isinstance(src, gftp.GftpSource)
+                    sources.append(src)
+                    byte_uploads += 1
+
+                elif sources:
+                    break
+
+            # simulate batch execution
+            await asyncio.sleep(0.05 * random.randint(0, 4))
+
+            # simulate post() calls
+            for src in sources:
+                await provider.release_source(src)
+
+            # Check if there aren't too many temporary files.
+            # There should be never be more temporary files than the number
+            # of possible URLs ("a", "b", "c" or "d")
+            tempfiles = list(Path(temp_dir).glob("*"))
+            print(
+                f"Number of temp files: {len(tempfiles)}, "
+                f"file uploads: {file_uploads}, "
+                f"bytes uploads: {byte_uploads}"
+            )
+            assert len(tempfiles) <= 4
+
+    async with gftp.GftpProvider(tmpdir=temp_dir, _close_urls=True) as provider:
+
+        assert isinstance(provider, gftp.GftpProvider)
+        loop = asyncio.get_event_loop()
+        workers = [loop.create_task(worker(n, provider)) for n in range(num_workers)]
+
+        await asyncio.gather(*workers)
+
+    # At this point the assertions in the fixtures for `temp_dir` and `test_dir`
+    # will check if all files from `temp_dir` were deleted and if no files from
+    # `test_dir` were deleted.
+
 
 ME = __file__
 
@@ -18,7 +184,7 @@ async def test_gftp_service():
         print("myself=", link["url"])
         await asyncio.sleep(1)
         print("close result= ", await server.close(urls=[link["url"]]))
-        with TemporaryDirectory() as tempdir:
+        with tempfile.TemporaryDirectory() as tempdir:
             output_file = Path(tempdir) / "out.txt"
             recv_url = await server.receive(output_file=str(output_file))
             print("recv_url=", recv_url)

--- a/yapapi/ctx.py
+++ b/yapapi/ctx.py
@@ -95,6 +95,10 @@ class _SendWork(Work, abc.ABC):
             _from=self._src.download_url, _to=f"container:{self._dst_path}"
         )
 
+    async def post(self) -> None:
+        assert self._src is not None
+        await self._storage.release_source(self._src)
+
 
 class _SendBytes(_SendWork):
     def __init__(self, storage: StorageProvider, data: bytes, dst_path: str):

--- a/yapapi/storage/__init__.py
+++ b/yapapi/storage/__init__.py
@@ -97,6 +97,12 @@ class InputStorageProvider(abc.ABC):
 
         return await self.upload_stream(file_size, read_file())
 
+    async def release_source(self, source: Source) -> None:
+        """Release a source returned by `upload_file` or `upload_bytes`.
+
+        The default implementation is to do nothing."""
+        pass
+
 
 class OutputStorageProvider(abc.ABC):
     @abc.abstractmethod

--- a/yapapi/storage/gftp.py
+++ b/yapapi/storage/gftp.py
@@ -4,20 +4,30 @@ Golem File Transfer Storage Provider
 
 import asyncio
 import contextlib
-import hashlib
+from dataclasses import dataclass
 import json
 import os
 import sys
 import tempfile
-import uuid
 from os import PathLike
 from pathlib import Path
 from types import TracebackType
-from typing import List, Optional, cast, Union, AsyncIterator, Iterator, Type, Dict
+from typing import (
+    AsyncContextManager,
+    AsyncIterator,
+    cast,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Type,
+    Union,
+)
 
 import jsonrpc_base  # type: ignore
 from async_exit_stack import AsyncExitStack  # type: ignore
-from typing_extensions import Protocol, Literal, TypedDict, AsyncContextManager
+from typing_extensions import Literal, Protocol, TypedDict
 
 from yapapi.storage import StorageProvider, Destination, Source, Content
 import logging
@@ -54,7 +64,7 @@ class GftpDriver(Protocol):
         """
         pass
 
-    async def close(self, *, urls: List[str]) -> CommandStatus:
+    async def close(self, *, urls: List[str]) -> List[CommandStatus]:
         """Stops exposing GFTP urls created by [publish(files=[..])](#publish)."""
         pass
 
@@ -150,10 +160,13 @@ class __Process(jsonrpc_base.Server):
 
 @contextlib.contextmanager
 def _temp_file(temp_dir: Path) -> Iterator[Path]:
-    file_name = temp_dir / str(uuid.uuid4())
-    yield file_name
-    if file_name.exists():
-        os.remove(file_name)
+    _, file_name = tempfile.mkstemp(prefix="yapapi_", dir=temp_dir)
+    yield Path(file_name)
+    if os.path.exists(file_name):
+        try:
+            os.remove(file_name)
+        except Exception:
+            _logger.error("Cannot remove temp file %s", file_name, exc_info=True)
 
 
 class GftpSource(Source):
@@ -164,6 +177,10 @@ class GftpSource(Source):
     @property
     def download_url(self) -> str:
         return self._link["url"]
+
+    @property
+    def path(self) -> Path:
+        return Path(self._link["file"])
 
     async def content_length(self) -> int:
         return self._len
@@ -197,21 +214,70 @@ class GftpDestination(Destination):
         return await super().download_file(destination_file)
 
 
-class GftpProvider(StorageProvider, AsyncContextManager[StorageProvider]):
-    _temp_dir: Optional[Path]
-    _registered_sources: Dict[str, GftpSource]
+def _try_delete(path: Path) -> None:
+    try:
+        if path.exists():
+            path.unlink()
+            _logger.debug("Deleted %s", path)
+    except Exception as e:
+        # Dont' report it as an error, `path` could be removed
+        # by some external process
+        _logger.debug("Cannot remove path %s: %s", path, e)
 
-    def __init__(self, *, tmpdir: Optional[str] = None):
+
+class GftpProvider(StorageProvider, AsyncContextManager[StorageProvider]):
+    """A StorageProvider that communicates with `gftp server` through JSON-RPC."""
+
+    @dataclass
+    class URLInfo:
+        """Information about an URL published through `gftp`."""
+
+        publish_count: int
+        """Number of `gftp publish` operations for this URL.
+
+        Serves as a reference counter. When it drops to 0, `gftp close <url>` should be invoked,
+        in order to release `self.current_file` kept open by `gftp`.
+        Note that this field may be larger than the number of files published, since a single
+        file may be published more than once."""
+
+        temporary_files: Set[Path]
+        """Set of temporary files published with this URL.
+
+        When a temporary file is released, it may be safely deleted,
+        unless it's `self.current_file`.
+        """
+
+        current_file: Path
+        """Most recently published file with this URL.
+
+        The assumption is that for each URL, `gftp` keeps open only the most recently
+        file that resolves to this URL. So we keep track of this file in order not to
+        delete is while it is still needed.
+        """
+
+    def __init__(self, *, tmpdir: Optional[str] = None, _close_urls: bool = False):
         self.__exit_stack = AsyncExitStack()
-        self._temp_dir = Path(tmpdir) if tmpdir else None
-        self._registered_sources = dict()
+        self._temp_dir: Optional[Path] = Path(tmpdir) if tmpdir else None
+        # Mapping of URLs to info on files published with this URL
+        self._published_sources: Dict[str, GftpProvider.URLInfo] = dict()
+        # Lock used to synchronize access to self._published_sources
+        self._lock = asyncio.Lock()
+        # If set to `True` then the provider will call `gftp close <URL>` for an URL
+        # that has no longer any published files. This should be the default behavior,
+        # but is currently turned off until a bug in `gftp` is fixed in `yagna 0.7.3`
+        # (see https://github.com/golemfactory/yagna/pull/1501)
+        self._close_urls = _close_urls
+
         self._process = None
 
     async def __aenter__(self) -> StorageProvider:
-        self._temp_dir = Path(self.__exit_stack.enter_context(tempfile.TemporaryDirectory()))
+        if not self._temp_dir:
+            self._temp_dir = Path(
+                self.__exit_stack.enter_context(tempfile.TemporaryDirectory(prefix="yapapi-gftp-"))
+            )
+            _logger.debug("Creating a temporary directory %s", self._temp_dir)
         process = await self.__get_process()
         _ver = await process.version()
-        # TODO check version
         assert _ver
         return self
 
@@ -222,15 +288,20 @@ class GftpProvider(StorageProvider, AsyncContextManager[StorageProvider]):
         traceback: Optional[TracebackType],
     ) -> Optional[bool]:
         await self.__exit_stack.aclose()
+        # Remove temporary files created by this provider
+        if not self._temp_dir:
+            raise RuntimeError("GftpProvider.__aenter__() not called")
+        if self._temp_dir and self._temp_dir.exists():
+            for info in self._published_sources.values():
+                for path in info.temporary_files:
+                    _try_delete(path)
+
         return None
 
     def __new_file(self) -> Path:
-        temp_dir: Path = self._temp_dir or Path(
-            self.__exit_stack.enter_context(tempfile.TemporaryDirectory())
-        )
         if not self._temp_dir:
-            self._temp_dir = temp_dir
-        return self.__exit_stack.enter_context(_temp_file(temp_dir))
+            raise RuntimeError("GftpProvider.__aenter__() not called")
+        return self.__exit_stack.enter_context(_temp_file(self._temp_dir))
 
     async def __get_process(self) -> GftpDriver:
         _debug = bool(os.getenv("DEBUG_GFTP"))
@@ -244,29 +315,89 @@ class GftpProvider(StorageProvider, AsyncContextManager[StorageProvider]):
         with open(file_name, "wb") as f:
             async for chunk in stream:
                 f.write(chunk)
-        return await self.upload_file(file_name)
+        return await self.upload_file(file_name, _temporary=True)
 
-    async def upload_file(self, path: os.PathLike) -> Source:
-        hasher = hashlib.sha3_256()
-        with open(path, "rb") as f:
-            while True:
-                bytes = f.read(4096)
-                if not bytes:
-                    break
-                hasher.update(bytes)
-        digest = hasher.hexdigest()
-        if digest in self._registered_sources:
-            _logger.debug("File %s already published, digest: %s", path, digest)
-            return self._registered_sources[digest]
-        _logger.debug("Publishing file %s, digest: %s", path, digest)
+    async def upload_file(self, path: os.PathLike, _temporary: bool = False) -> Source:
 
+        path = Path(path)
+        _logger.debug("Publishing file %s...", path)
         process = await self.__get_process()
-        links = await process.publish(files=[str(path)])
-        length = Path(path).stat().st_size
-        assert len(links) == 1, "invalid gftp publish response"
+
+        async with self._lock:
+
+            links = await process.publish(files=[str(path)])
+            assert len(links) == 1, "Invalid gftp publish response"
+
+            length = path.stat().st_size
+
+            url = links[0]["url"]
+
+            if url not in self._published_sources:
+                info = GftpProvider.URLInfo(
+                    publish_count=1,
+                    temporary_files=({path} if _temporary else set()),
+                    current_file=path,
+                )
+                self._published_sources[url] = info
+            else:
+                info = self._published_sources[url]
+
+                if path in info.temporary_files:
+                    raise ValueError(f"File {path} already published as temporary")
+
+                if _temporary:
+                    info.temporary_files.add(path)
+                info.publish_count += 1
+                prev_file = info.current_file
+                info.current_file = path
+
+                if prev_file != info.current_file and prev_file in info.temporary_files:
+                    _try_delete(prev_file)
+
+            _logger.debug(
+                "File %s published with URL = %s, count = %d", path, url, info.publish_count
+            )
+
         source = GftpSource(length, links[0])
-        self._registered_sources[digest] = source
         return source
+
+    async def release_source(self, source: Source) -> None:
+
+        if not isinstance(source, GftpSource):
+            raise ValueError(f"Expected an instance of GftpSource, got {type(source)} instead")
+
+        url = source.download_url
+        _logger.debug("Releasing file %s with URL = %s ...", source.path, url)
+
+        async with self._lock:
+
+            if url not in self._published_sources:
+                raise ValueError(
+                    f"Trying to release an unpublished URL {url}, path = {source.path}"
+                )
+            info = self._published_sources[url]
+            info.publish_count -= 1
+
+            _logger.debug(
+                "File %s released, URL = %s, count = %d", source.path, url, info.publish_count
+            )
+
+            if source.path in info.temporary_files and source.path != info.current_file:
+                _try_delete(source.path)
+                info.temporary_files.remove(source.path)
+
+            if info.publish_count == 0:
+
+                _logger.debug("Unpublishing URL %s...", url)
+                # TODO: make it a default when this is supported by `gftp`:
+                if self._close_urls:
+                    process = await self.__get_process()
+                    await process.close(urls=[url])
+
+                for path in info.temporary_files:
+                    _try_delete(path)
+
+                del self._published_sources[url]
 
     async def new_destination(self, destination_file: Optional[PathLike] = None) -> Destination:
         if destination_file:


### PR DESCRIPTION
Resolves #531
Resolves #519

This PR addresses the problem of temporary files kept open by `gftp` even when they are not needed anymore.

For each published gftp URL (gftp uses content addressing, so two files with the same content published on the same node would have the same URL), the `gftp server` command keeps one file open (it's the last one published with given URL). 

After a file is transferred to provider (or, more precisely, after all transfers for the given URL are completed), it should be closed by sending `close <url>` command to the `gftp` server, otherwise the number of open files will increase. This is especially true for temporary files created to execute `ctx.upload_json()` or `ctx.upload_bytes()` -- each such file is only needed for a single `transfer` operation.

This PR implements reference counting for published URLs and issuing `gftp close` commands for URLs for which the counter drops to `0`. This functionality has been unit-tested, **however, it disabled in the current PR, since the command `gftp close` is not implemented correctly in `yagna 0.7.2`. A fix for `gftp` is currently scheduled to beta.2.patch.3 release, see https://github.com/golemfactory/yagna/pull/1501.**


## Note

I'm marking this as a draft. It probably makes no sense to merge this partial solution, let's wait for the next `yagna` release with fixed `gftp close`. Especially since this PR does not work for Windows as is (some temporary files are being deleted while being open by `gftp`, which is fine for Unix but not on Windows).


## Update

The changes have been tested with `yagna v0.7.3-rc2` and work well. To ensure compatibility with older versions of `yagna`, calling `gftp close` is now disabled by default and can be enabled by using a flag when creating an instance of a storage provider:
```python
async with GftpProvider(_close_urls=True) as provider: ...
```