### PR TITLE
Make engine params configurable via env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,16 @@ if __name__ == "__main__":
     task = loop.create_task(main())
     loop.run_until_complete(task)
 ```
+
+## Environment variables
+
+It's possible to set various elements of `yagna` configuration through environment variables.
+`yapapi` currently supports the following environment variables:
+- `YAGNA_ACTIVITY_URL`, URL to `yagna` activity API, e.g. `http://localhost:7500/activity-api/v1`
+- `YAGNA_API_URL`, base URL to `yagna` REST API, e.g. `http://localhost:7500`
+- `YAGNA_APPKEY`, `yagna` app key to be used, e.g. `a70facb9501d4528a77f25574ab0f12b`
+- `YAGNA_MARKET_URL`, URL to `yagna` market API, e.g. `http://localhost:7500/market-api/v1`
+- `YAGNA_NETWORK`, Ethereum network name for `yagna` to use, e.g. `rinkeby`
+- `YAGNA_PAYMENT_DRIVER`, payment driver name for `yagna` to use, e.g. `zksync`
+- `YAGNA_PAYMENT_URL`, URL to `yagna` payment API, e.g. `http://localhost:7500/payment-api/v1`
+- `YAGNA_SUBNET`, name of the `yagna` sub network to be used, e.g. `devnet-beta.2`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,44 @@
 [![GitHub license](https://img.shields.io/github/license/golemfactory/yapapi)](https://github.com/golemfactory/yapapi/blob/master/LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/golemfactory/yapapi)](https://github.com/golemfactory/yapapi/issues)
 
+## Installation
+
+`yapapi` is available as a [PyPI package](https://pypi.org/project/yapapi/0.6.2/).
+
+You can install it through `pip`:
+```
+pip install yapapi
+```
+
+Or if your project uses [`poetry`](https://python-poetry.org/) you can add it to your dependencies like this:
+```
+poetry add yapapi
+```
+
+### Local development setup
+
+#### Poetry
+`yapapi` uses [`poetry`](https://python-poetry.org/) to manage its dependencies and provide a runner for common tasks.
+
+If you don't have `poetry` available on your system then follow its [installation instructions](https://python-poetry.org/docs/#installation) before proceeding.
+Verify your installation by running:
+```
+poetry --version
+```
+
+#### Project dependencies
+To install the project's dependencies run:
+```
+poetry install
+```
+By default, `poetry` looks for the required Python version on your `PATH` and creates a virtual environment for the project if there's none active (or already configured by Poetry).
+
+All of the project's dependencies will be installed to that virtual environment.
+
+If you'd like to run the `yapapi` integration test suite locally then you'll need to install an additional set of dependencies separately by running:
+```
+poetry install -E integration-tests
+```
 ## What's Golem, btw?
 
 [Golem](https://golem.network) is a global, open-source, decentralized supercomputer
@@ -44,7 +82,6 @@ do that in the [yagna repository](https://github.com/golemfactory/yagna) and in 
   [`examples/hello-world/`](https://github.com/golemfactory/yapapi/tree/master/examples/hello-world)
   contains minimal examples of fully functional requestor agents and
   is therefore the best place to start exploring.
-
 
 ### Components
 


### PR DESCRIPTION
Resolves #545 

This adds the ability to configure a number of engine parameters (payment driver, payment network and `yagna` subnet) through environment variables.
I've also updated the project's readme:
- added a list of environment variables we currently support
- added a section on how to install `yapapi`, as well as how to set it up for local development (not directly related to this PR's issue)