### PR TITLE
Don't spawn another instance if one instance stops due to a signal

### DIFF
--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -593,8 +593,13 @@ class Cluster(AsyncContextManager):
             try:
                 await task
                 if (
+                    # if the instance was created ...
                     instance
+                    # but failed to start ...
                     and not instance.started_successfully
+                    # due to an error (and not a `STOP` signal) ...
+                    and instance.service.exc_info() != (None, None, None)
+                    # and re-spawning instances is enabled for this cluster
                     and self._respawn_unstarted_instances
                 ):
                     logger.warning("Instance failed when starting, trying to create another one...")


### PR DESCRIPTION
Resolves #544 

Changes in this PR

* Before spawning an instance in place of another instance stopped in `starting` state, check if that instance was stopped due to an error and not due to a `STOP` signal.
* Extend the integration test for re-spawning instances to check that a cluster does not automatically spawn new instances after `Cluster.stop()` is called.