### PR TITLE
Read env var to determine if GftpProvider shoud call `gftp close`

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,17 @@ if __name__ == "__main__":
     task = loop.create_task(main())
     loop.run_until_complete(task)
 ```
+
+## Environment variables
+
+It's possible to set various elements of `yagna` configuration through environment variables.
+`yapapi` currently supports the following environment variables:
+- `YAGNA_ACTIVITY_URL`, URL to `yagna` activity API, e.g. `http://localhost:7500/activity-api/v1`
+- `YAGNA_API_URL`, base URL to `yagna` REST API, e.g. `http://localhost:7500`
+- `YAGNA_APPKEY`, `yagna` app key to be used, e.g. `a70facb9501d4528a77f25574ab0f12b`
+- `YAGNA_MARKET_URL`, URL to `yagna` market API, e.g. `http://localhost:7500/market-api/v1`
+- `YAGNA_PAYMENT_URL`, URL to `yagna` payment API, e.g. `http://localhost:7500/payment-api/v1`
+- `YAPAPI_USE_GFTP_CLOSE`, if set to a _truthy_ value (e.g. "1", "Y", "True", "on") then `yapapi`
+  will ask `gftp` to close files when there's no need to publish them any longer. This may greatly
+  reduce the number of files kept open while `yapapi` is running but requires `yagna`
+  0.7.3 or newer, with older versions it will cause errors.


### PR DESCRIPTION
A follow-up for https://github.com/golemfactory/yapapi/pull/543.

Makes `GftpProvider` read the "YAPAPI_USE_GFTP_CLOSE" variable from the environment. If this variable is set to a value that can be interpreted as `True` by `distutils.util.strtobool()` then `gftp close URL` will be issued by `GftpProvider` for each URL that does not have any published files (see the description of https://github.com/golemfactory/yapapi/pull/543 for more details).

This is to allow app developers to control the behavior of `GftpProvider` without changing the public API of `yapapi`. (One may argue that using a new environment variable does in fact extend the public API, but -- come on)