### PR TITLE
Fix demand resubscription test with goth 0.6.2

### DIFF
--- a/.github/workflows/goth-nightly.yml
+++ b/.github/workflows/goth-nightly.yml
@@ -22,7 +22,7 @@ jobs:
         id: latest-stable
         # second sed expression removes leading whitespaces and '*' characters (git uses it to indicate the current branch)
         run: |
-          branch=$(git branch -a | sed -e 's:remotes/origin/::' -e 's:^[ \t*]*::' | grep -E '^release\/v[0-9]+(\.[0-9]+)+$' | sort -Vr | head -1)
+          branch=$(git branch -a | sed -e 's:remotes/origin/::' -e 's:^[ \t*]*::' | grep -E '^b[0-9]+(\.[0-9]+)+$' | sort -Vr | head -1)
           echo "::set-output name=branch::$branch"
 
       # prepares JSON object representing strategy matrix which contains two 'branch' variants: master and latest stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ rich = { version = "^10.2", optional = true }
 async_exit_stack = "^1.0.1"
 jsonrpc-base = "^1.0.3"
 
-ya-aioclient = "^0.5.0"
+ya-aioclient = "^0.6"
 toml = "^0.10.1"
 srvresolver = "^0.3.5"
 colorama = "^0.4.4"
@@ -44,7 +44,8 @@ colorama = "^0.4.4"
 # It will be then installable with `poetry install -E integration-tests`.
 # Note that putting `goth` in `poetry.dev-dependencies` instead of `poetry.dependencies`
 # would not work: see https://github.com/python-poetry/poetry/issues/129.
-goth = { version = "^0.5", optional = true, python = "^3.8.0" }
+goth = { version = "^0.6", optional = true, python = "^3.8.0" }
+# goth = { git = "https://github.com/golemfactory/goth.git", branch = "your-branch-name", optional = true, python = "^3.8.0", develop = true }
 Deprecated = "^1.2.12"
 python-statemachine = "^0.8.0"
 

--- a/tests/goth_tests/test_resubscription.py
+++ b/tests/goth_tests/test_resubscription.py
@@ -151,8 +151,8 @@ async def test_demand_resubscription(log_dir: Path, goth_config_path: Path, monk
     async with runner(goth_config.containers):
 
         requestor = runner.get_probes(probe_type=RequestorProbe)[0]
-        env = {**os.environ}
-        requestor.set_agent_env_vars(env)
+        env = requestor.get_agent_env_vars()
+        env.update(**os.environ)
 
         # Setup the environment for the requestor
         for key, val in env.items():

--- a/yapapi/rest/payment.py
+++ b/yapapi/rest/payment.py
@@ -145,6 +145,7 @@ class Payment(object):
                 total_amount=str(amount),
                 timeout=allocation_timeout,
                 make_deposit=make_deposit,
+                timestamp=datetime.now(timezone.utc),
                 # TODO: fix this
                 spent_amount="",
                 remaining_amount="",


### PR DESCRIPTION
Scope of changes:
- cherry-pick of #503 (includes updating `goth` to `0.6+`)
- fix demand resubscription test failing with `goth` version `0.6.2` (e.g. https://github.com/golemfactory/yapapi/runs/3307126887?check_suite_focus=true)
- fix stable branch name regex in `goth` nightly workflow