### PR TITLE
Add semantic-version to dependencies, bump version to 0.6.3-alpha.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "yapapi"
-version = "0.6.3-alpha.0"
+version = "0.6.3-alpha.1"
 description = "High-level Python API for the New Golem"
 authors = ["Przemysław K. Rekucki <przemyslaw.rekucki@golem.network>", "GolemFactory <contact@golem.network>"]
 license = "LGPL-3.0-or-later"
@@ -36,6 +36,7 @@ ya-aioclient = "^0.5.0"
 toml = "^0.10.1"
 srvresolver = "^0.3.5"
 colorama = "^0.4.4"
+semantic-version="^2.8"
 
 # Adding `goth` to dependencies causes > 40 additional packages to be installed. Given
 # that dependency resolution in `poetry` is rather slow, we'd like to avoid installing


### PR DESCRIPTION
Added `semantic-version` to `yapapi` dependencies (was a transitive dependency of  `dev-dependencies` before).