### PR TITLE
Custom usage counter support

### DIFF
--- a/tests/props/test_com.py
+++ b/tests/props/test_com.py
@@ -13,8 +13,8 @@ def test_com_linear_fixed_price():
 
 def test_com_linear_price_for():
     com: ComLinear = ComLinearFactory(linear_coeffs=LINEAR_COEFFS, usage_vector=DEFINED_USAGES)
-    assert com.price_for[Counter.CPU] == LINEAR_COEFFS[0]
-    assert com.price_for[Counter.TIME] == LINEAR_COEFFS[1]
+    assert com.price_for[Counter.CPU.value] == LINEAR_COEFFS[0]
+    assert com.price_for[Counter.TIME.value] == LINEAR_COEFFS[1]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -161,18 +161,6 @@ class TestLeastExpensiveLinearPayuMS:
         assert await self.strategy.score_offer(offer1) == await self.strategy.score_offer(offer2)
 
     @pytest.mark.asyncio
-    async def test_score_unknown_price(self):
-        offer = OfferProposalFactory(
-            **{
-                "proposal__proposal__properties__usage_vector": [
-                    Counter.MAXMEM.value,
-                    Counter.TIME.value,
-                ]
-            }
-        )
-        assert await self.strategy.score_offer(offer) == SCORE_REJECTED
-
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "coeffs", [[-0.001, 0.002, 0.1], [0.001, -0.002, 0.1], [0.001, 0.002, -0.1]]
     )

--- a/yapapi/ctx.py
+++ b/yapapi/ctx.py
@@ -575,5 +575,5 @@ class CaptureContext:
 class ActivityUsage:
     """A high-level representation of activity usage record."""
 
-    current_usage: Dict[Counter, float] = field(default_factory=dict)
+    current_usage: Dict[str, float] = field(default_factory=dict)
     timestamp: Optional[datetime] = None

--- a/yapapi/props/com.py
+++ b/yapapi/props/com.py
@@ -70,15 +70,12 @@ class ComLinear(Com):
         return self.linear_coeffs[-1]
 
     @property
-    def price_for(self) -> Dict[Counter, float]:
-        return {
-            Counter(self.usage_vector[i]): self.linear_coeffs[i]
-            for i in range(len(self.usage_vector))
-        }
+    def price_for(self) -> Dict[str, float]:
+        return {u: self.linear_coeffs[i] for (i, u) in enumerate(self.usage_vector)}
 
     def calculate_cost(self, usage: List):
         usage = usage + [1.0]  # append the "usage" of the fixed component
-        return sum([self.linear_coeffs[i] * usage[i] for i in range(len(self.linear_coeffs))])
+        return sum([c * usage[i] for (i, c) in enumerate(self.linear_coeffs)])
 
-    def usage_as_dict(self, usage: List) -> Dict[Counter, float]:
-        return {Counter(self.usage_vector[i]): usage[i] for i in range(len(usage))}
+    def usage_as_dict(self, usage: List) -> Dict[str, float]:
+        return {self.usage_vector[i]: u for (i, u) in enumerate(usage)}


### PR DESCRIPTION
This PR allows for handling offers with custom usage counters (e.g. defined by services built with `ya-runtime-sdk`)

- usage counters are no longer constrained by `Counter` enum
- rework market strategies to use counter property names instead of the `Counter` enum
- unify construction of dummy and linear market strategy objects