### PR TITLE
Adapt integration tests to goth version 0.6.3

### DIFF
--- a/.github/workflows/goth-nightly.yml
+++ b/.github/workflows/goth-nightly.yml
@@ -22,7 +22,7 @@ jobs:
         id: latest-stable
         # second sed expression removes leading whitespaces and '*' characters (git uses it to indicate the current branch)
         run: |
-          branch=$(git branch -a | sed -e 's:remotes/origin/::' -e 's:^[ \t*]*::' | grep -E '^release\/v[0-9]+(\.[0-9]+)+$' | sort -Vr | head -1)
+          branch=$(git branch -a | sed -e 's:remotes/origin/::' -e 's:^[ \t*]*::' | grep -E '^b[0-9]+(\.[0-9]+)+$' | sort -Vr | head -1)
           echo "::set-output name=branch::$branch"
 
       # prepares JSON object representing strategy matrix which contains two 'branch' variants: master and latest stable

--- a/tests/goth_tests/test_resubscription.py
+++ b/tests/goth_tests/test_resubscription.py
@@ -151,8 +151,8 @@ async def test_demand_resubscription(log_dir: Path, goth_config_path: Path, monk
     async with runner(goth_config.containers):
 
         requestor = runner.get_probes(probe_type=RequestorProbe)[0]
-        env = {**os.environ}
-        requestor.set_agent_env_vars(env)
+        env = dict(os.environ)
+        env.update(requestor.get_agent_env_vars())
 
         # Setup the environment for the requestor
         for key, val in env.items():


### PR DESCRIPTION
Cherry-pick of https://github.com/golemfactory/yapapi/pull/593
Also updates resubscription test to change the usage of `Probe.get_agent_env_vars`.