### PR TITLE
Johny b/561 non context manager

### DIFF
--- a/examples/hello-world/hello.py
+++ b/examples/hello-world/hello.py
@@ -6,8 +6,6 @@ from yapapi import Golem, Task, WorkContext
 from yapapi.log import enable_default_logger
 from yapapi.payload import vm
 
-golem = Golem(budget=1.0, subnet_tag="devnet-beta.2")
-
 
 async def worker(context: WorkContext, tasks: AsyncIterable[Task]):
     async for task in tasks:
@@ -23,14 +21,16 @@ async def main():
         image_hash="d646d7b93083d817846c2ae5c62c72ca0507782385a2e29291a3d376",
     )
 
-    tasks = [Task(data=None) for _ in range(7)]
+    tasks = [Task(data=None) for _ in range(2)]
 
     async for completed in golem.execute_tasks(worker, tasks, payload=package, max_workers=3):
         print(completed.result.stdout)
+    await golem.stop()
 
 
 if __name__ == "__main__":
     enable_default_logger(log_file="hello.log")
+    golem = Golem(budget=1.0, subnet_tag="devnet-beta.2")
 
     loop = asyncio.get_event_loop()
     task = loop.create_task(main())

--- a/examples/hello-world/hello.py
+++ b/examples/hello-world/hello.py
@@ -6,6 +6,8 @@ from yapapi import Golem, Task, WorkContext
 from yapapi.log import enable_default_logger
 from yapapi.payload import vm
 
+golem = Golem(budget=1.0, subnet_tag="devnet-beta.2")
+
 
 async def worker(context: WorkContext, tasks: AsyncIterable[Task]):
     async for task in tasks:
@@ -23,9 +25,10 @@ async def main():
 
     tasks = [Task(data=None)]
 
-    async with Golem(budget=1.0, subnet_tag="devnet-beta.2") as golem:
-        async for completed in golem.execute_tasks(worker, tasks, payload=package):
-            print(completed.result.stdout)
+    await golem.start()
+    async for completed in golem.execute_tasks(worker, tasks, payload=package):
+        print(completed.result.stdout)
+    await golem.stop()
 
 
 if __name__ == "__main__":

--- a/examples/hello-world/hello.py
+++ b/examples/hello-world/hello.py
@@ -23,11 +23,10 @@ async def main():
         image_hash="d646d7b93083d817846c2ae5c62c72ca0507782385a2e29291a3d376",
     )
 
-    tasks = [Task(data=None)]
+    tasks = [Task(data=None) for _ in range(7)]
 
-    async for completed in golem.execute_tasks(worker, tasks, payload=package):
+    async for completed in golem.execute_tasks(worker, tasks, payload=package, max_workers=3):
         print(completed.result.stdout)
-    await golem.stop()
 
 
 if __name__ == "__main__":
@@ -35,4 +34,11 @@ if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
     task = loop.create_task(main())
-    loop.run_until_complete(task)
+    try:
+        loop.run_until_complete(task)
+    except KeyboardInterrupt:
+        task.cancel()
+        try:
+            loop.run_until_complete(task)
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            pass

--- a/examples/hello-world/hello.py
+++ b/examples/hello-world/hello.py
@@ -25,7 +25,6 @@ async def main():
 
     tasks = [Task(data=None)]
 
-    await golem.start()
     async for completed in golem.execute_tasks(worker, tasks, payload=package):
         print(completed.result.stdout)
     await golem.stop()

--- a/examples/hello-world/hello.py
+++ b/examples/hello-world/hello.py
@@ -21,24 +21,16 @@ async def main():
         image_hash="d646d7b93083d817846c2ae5c62c72ca0507782385a2e29291a3d376",
     )
 
-    tasks = [Task(data=None) for _ in range(2)]
+    tasks = [Task(data=None)]
 
-    async for completed in golem.execute_tasks(worker, tasks, payload=package, max_workers=3):
-        print(completed.result.stdout)
-    await golem.stop()
+    async with Golem(budget=1.0, subnet_tag="devnet-beta.2") as golem:
+        async for completed in golem.execute_tasks(worker, tasks, payload=package):
+            print(completed.result.stdout)
 
 
 if __name__ == "__main__":
     enable_default_logger(log_file="hello.log")
-    golem = Golem(budget=1.0, subnet_tag="devnet-beta.2")
 
     loop = asyncio.get_event_loop()
     task = loop.create_task(main())
-    try:
-        loop.run_until_complete(task)
-    except KeyboardInterrupt:
-        task.cancel()
-        try:
-            loop.run_until_complete(task)
-        except (asyncio.CancelledError, KeyboardInterrupt):
-            pass
+    loop.run_until_complete(task)

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -229,6 +229,14 @@ class _Engine(AsyncContextManager):
         """Return the name of the subnet used by this engine, or `None` if it is not set."""
         return self._subnet
 
+    @property
+    def operative(self) -> bool:
+        #   TODO: Implement this in some clean way
+        #         Also: other properties don't work in non-started state, how do we deal with this?
+        started = hasattr(self, '_storage_manager')
+        stopped = hasattr(self, '_stopped')
+        return started and not stopped
+
     def emit(self, event: events.Event) -> None:
         """Emit an event to be consumed by this engine's event consumer."""
         if self._wrapped_consumer:
@@ -248,6 +256,7 @@ class _Engine(AsyncContextManager):
         return await self.stop()
 
     async def stop(self) -> Optional[bool]:
+        self._stopped = True  # TODO -> check "operative" attribute
         return await self._stack.__aexit__(*sys.exc_info())
 
     async def start(self) -> None:

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -9,7 +9,6 @@ import itertools
 import logging
 import os
 import sys
-import atexit
 from typing import (
     AsyncContextManager,
     Awaitable,

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -192,9 +192,6 @@ class _Engine(AsyncContextManager):
         self._services: Set[asyncio.Task] = set()
         self._stack = AsyncExitStack()
 
-        # changed in _start/_stop methods
-        self._operative: bool = False
-
     async def create_demand_builder(
         self, expiration_time: datetime, payload: Payload
     ) -> DemandBuilder:
@@ -232,10 +229,6 @@ class _Engine(AsyncContextManager):
         """Return the name of the subnet used by this engine, or `None` if it is not set."""
         return self._subnet
 
-    @property
-    def operative(self) -> bool:
-        return self._operative
-
     def emit(self, event: events.Event) -> None:
         """Emit an event to be consumed by this engine's event consumer."""
         if self._wrapped_consumer:
@@ -253,11 +246,9 @@ class _Engine(AsyncContextManager):
         return await self._stop(*exc_info)
 
     async def _stop(self, *exc_info) -> Optional[bool]:
-        self._operative = False
         return await self._stack.__aexit__(*exc_info)
 
     async def _start(self) -> None:
-        self._operative = True
         stack = self._stack
 
         await stack.enter_async_context(self._wrapped_consumer)

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -192,7 +192,7 @@ class _Engine(AsyncContextManager):
         self._services: Set[asyncio.Task] = set()
         self._stack = AsyncExitStack()
 
-        # changed in start/stop methods
+        # changed in _start/_stop methods
         self._operative: bool = False
 
     async def create_demand_builder(

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -241,14 +241,14 @@ class _Engine(AsyncContextManager):
             await self.start()
             return self
         except:
-            await self.stop(*sys.exc_info())
+            await self.stop()
             raise
 
     async def __aexit__(self, *exc_info) -> Optional[bool]:
         return await self.stop()
 
     async def stop(self) -> Optional[bool]:
-        return await self._stack.__aexit__(None, None, None)
+        return await self._stack.__aexit__(*sys.exc_info())
 
     async def start(self) -> None:
         stack = self._stack

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -59,6 +59,7 @@ class Golem(_Engine):
     either mode of operation, it's usually good to have just one instance of `Golem` active
     at any given time.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -58,6 +58,7 @@ class Golem(_Engine):
     either mode of operation, it's usually good to have just one instance of `Golem` active
     at any given time.
     """
+
     async def start(self) -> None:
         """Initialize resources and start background services used by this engine.
 
@@ -74,6 +75,7 @@ class Golem(_Engine):
         """
         if self.operative:
             return await self._stop(None, None, None)
+        return None
 
     async def execute_tasks(
         self,

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -58,6 +58,22 @@ class Golem(_Engine):
     either mode of operation, it's usually good to have just one instance of `Golem` active
     at any given time.
     """
+    async def start(self) -> None:
+        """Initialize resources and start background services used by this engine.
+
+        Calling this method is not necessary, it will be called either way internally
+        when the engine is used for the first time.
+        """
+        if not self.operative:
+            await self._start()
+
+    async def stop(self) -> Optional[bool]:
+        """Stop the engine in a graceful way.
+
+        This **must** be called when using Golem in a non-contextmanager way.
+        """
+        if self.operative:
+            return await self._stop(None, None, None)
 
     async def execute_tasks(
         self,

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -111,6 +111,8 @@ class Golem(_Engine):
                     print(completed.result.stdout)
         ```
         """
+        if not self.operative:
+            await self.start()
 
         kwargs: Dict[str, Any] = {"payload": payload}
         if max_workers:
@@ -203,6 +205,9 @@ class Golem(_Engine):
                     await asyncio.sleep(REFRESH_INTERVAL_SEC)
         ```
         """
+        if not self.operative:
+            await self.start()
+
         payload = payload or await service_class.get_payload()
 
         if not payload:

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -95,7 +95,7 @@ class Golem(_Engine):
         This **must** be called when using Golem in a non-contextmanager way.
         """
         if self._stop_future is None:
-            self._stop_future = asyncio.get_running_loop().create_future()
+            self._stop_future = asyncio.get_event_loop().create_future()
             result = await self._stop(None, None, None)
             self._stop_future.set_result(result)
         else:

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -79,7 +79,7 @@ class Golem(_Engine):
         when the engine is used for the first time.
         """
         if self._start_future is None:
-            self._start_future = asyncio.get_running_loop().create_future()
+            self._start_future = asyncio.get_event_loop().create_future()
             await self._start()
             self._start_future.set_result(None)
         else:

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -80,7 +80,7 @@ class Golem(_Engine):
         if self._start_future is None:
             self._start_future = asyncio.get_running_loop().create_future()
             await self._start()
-            self._start_future.set_result({'result': 'AA'})
+            self._start_future.set_result(None)
         else:
             if self._stop_future is not None:
                 #   Currently restarting a Golem that was stopped is not allowed.


### PR DESCRIPTION
**GENERAL NOTES**
This resolves #561, but there are follow-up tasks:
* #601
* #605
* #606

**THINGS DONE**

1. `_Engine._start()`, `_Engine._stop()` methods (no logic changes, just extracted code from `__aenter__/__aexit__`)
2. `Golem.operative` property
3. `Golem.start()`/`Golem.stop()`
4. `start()` is called in `Golem.execute_tasks` and `Golem.run_service` if it wasn't already called before