### PR TITLE
Golem <-> Engine refactoring

### DIFF
--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -11,6 +11,7 @@ import logging
 import os
 import sys
 from typing import (
+    AsyncContextManager,
     Awaitable,
     Callable,
     cast,
@@ -292,6 +293,9 @@ class _Engine:
         self._storage_manager = await stack.enter_async_context(gftp.provider())
 
         stack.push_async_exit(self._shutdown)
+
+    async def add_to_async_context(self, async_context_manager: AsyncContextManager) -> None:
+        await self._stack.enter_async_context(async_context_manager)
 
     def _unpaid_agreement_ids(self) -> Set[AgreementId]:
         """Return the set of all yet unpaid agreement ids."""

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -11,7 +11,6 @@ import logging
 import os
 import sys
 from typing import (
-    AsyncContextManager,
     Awaitable,
     Callable,
     cast,
@@ -111,7 +110,7 @@ JobId = str
 AgreementId = str
 
 
-class _Engine(AsyncContextManager):
+class _Engine:
     """Base execution engine containing functions common to all modes of operation."""
 
     def __init__(

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -236,18 +236,18 @@ class _Engine:
             self._wrapped_consumer.async_call(event)
 
     async def stop(self, *exc_info) -> Optional[bool]:
-        '''Stop the engine.
+        """Stop the engine.
 
         This *must* be called at the end of the work, by the Engine user.
-        '''
+        """
         return await self._stack.__aexit__(*exc_info)
 
     async def start(self):
-        '''Start the engine.
+        """Start the engine.
 
         This is supposed to be called exactly once. Repeated or interrupted call
         will leave the engine in an unrecoverable state.
-        '''
+        """
 
         stack = self._stack
 

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -334,9 +334,9 @@ class Golem:
 
         :return: a Network object allowing further manipulation of the created VPN
         """
-        async with self._root_api_session.get(f"{self._api_config.root_url}/me") as resp:
+        async with self._engine._root_api_session.get(f"{self._engine._api_config.root_url}/me") as resp:
             identity = json.loads(await resp.text()).get("identity")
 
         return await Network.create(
-            self._net_api, ip, identity, owner_ip, mask=mask, gateway=gateway
+            self._engine._net_api, ip, identity, owner_ip, mask=mask, gateway=gateway
         )

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -35,7 +35,6 @@ D = TypeVar("D")  # Type var for task data
 R = TypeVar("R")  # Type var for task result
 
 
-#   TODO: do we want to inherit from AsyncContextManager here?
 class Golem:
     """The main entrypoint of Golem's high-level API.
 
@@ -310,9 +309,8 @@ class Golem:
             respawn_unstarted_instances=respawn_unstarted_instances,
             network=network,
         )
-        #   TODO this is super ugly. How to fix this?
-        #   Maybe Engine.add_async_context(cluster)?
-        await self._engine._stack.enter_async_context(cluster)
+
+        await self._engine.add_to_async_context(cluster)
         cluster.spawn_instances(num_instances, instance_params, network_addresses)
 
         return cluster

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime, timedelta
 import json
 from typing import (
@@ -59,6 +60,17 @@ class Golem(_Engine):
     either mode of operation, it's usually good to have just one instance of `Golem` active
     at any given time.
     """
+
+    async def __aenter__(self) -> 'Golem':
+        try:
+            await self.start()
+            return self
+        except:
+            await self.__aexit__(*sys.exc_info())
+            raise
+
+    async def __aexit__(self, *exc_info) -> Optional[bool]:
+        return await self.stop(*exc_info)
 
     async def execute_tasks(
         self,

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -14,7 +14,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    TYPE_CHECKING
+    TYPE_CHECKING,
 )
 from typing_extensions import AsyncGenerator
 
@@ -71,7 +71,7 @@ class Golem:
         self,
         *,
         budget: Union[float, Decimal],
-        strategy: Optional['MarketStrategy'] = None,
+        strategy: Optional["MarketStrategy"] = None,
         subnet_tag: Optional[str] = None,
         driver: Optional[str] = None,
         network: Optional[str] = None,
@@ -80,14 +80,14 @@ class Golem:
         app_key: Optional[str] = None,
     ):
         self._init_args = {
-            'budget': budget,
-            'strategy': strategy,
-            'subnet_tag': subnet_tag,
-            'driver': driver,
-            'network': network,
-            'event_consumer': event_consumer,
-            'stream_output': stream_output,
-            'app_key': app_key,
+            "budget": budget,
+            "strategy": strategy,
+            "subnet_tag": subnet_tag,
+            "driver": driver,
+            "network": network,
+            "event_consumer": event_consumer,
+            "stream_output": stream_output,
+            "app_key": app_key,
         }
 
         self._engine: _Engine = self._get_new_engine()
@@ -103,7 +103,7 @@ class Golem:
         return self._engine.network
 
     @property
-    def strategy(self) -> 'MarketStrategy':
+    def strategy(self) -> "MarketStrategy":
         """Return the instance of `MarketStrategy` used by the engine"""
         return self._engine.strategy
 
@@ -112,7 +112,7 @@ class Golem:
         """Return the name of the subnet, or `None` if it is not set."""
         return self._engine.subnet_tag
 
-    async def __aenter__(self) -> 'Golem':
+    async def __aenter__(self) -> "Golem":
         try:
             await self._engine.start()
             return self
@@ -131,14 +131,14 @@ class Golem:
     def _get_new_engine(self):
         args = self._init_args
         return _Engine(
-            budget=args['budget'],
-            strategy=args['strategy'],
-            subnet_tag=args['subnet_tag'],
-            driver=args['driver'],
-            network=args['network'],
-            event_consumer=args['event_consumer'],
-            stream_output=args['stream_output'],
-            app_key=args['app_key'],
+            budget=args["budget"],
+            strategy=args["strategy"],
+            subnet_tag=args["subnet_tag"],
+            driver=args["driver"],
+            network=args["network"],
+            event_consumer=args["event_consumer"],
+            stream_output=args["stream_output"],
+            app_key=args["app_key"],
         )
 
     async def execute_tasks(
@@ -334,7 +334,9 @@ class Golem:
 
         :return: a Network object allowing further manipulation of the created VPN
         """
-        async with self._engine._root_api_session.get(f"{self._engine._api_config.root_url}/me") as resp:
+        async with self._engine._root_api_session.get(
+            f"{self._engine._api_config.root_url}/me"
+        ) as resp:
             identity = json.loads(await resp.text()).get("identity")
 
         return await Network.create(


### PR DESCRIPTION
Things done:
* `_Engine` is no longer an AsyncContextManager
* `Golem` doesn't inherit from `_Engine`
* `Golem.__aenter__` and `Golem.__aexit__`

NOTES:
1. This is almost a "pure" refactoring, everything is supposed to work as before
2. The only difference is that we have a new `_Engine` everytime we exit the golem context, this way e.g.
```
golem = Golem(budget=...)
with golem:
    golem.execute_tasks()
with golem:
    golem.execute_tasks(...)
```
should work (and probably didn't work until now, although I didn't check this thoroughly).
3. Some problems like "what if we enter `golem` context in more than one task at the same time" are not addressed. I plan to fix this while working on #561
4. This uses changes from #635 (in review) -> that's why checks are not running


This resolves #612.