### PR TITLE
pytest-rerunfailures in goth tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ ya-market = "0.1.0"
 [tool.poe.tasks]
 test = "pytest --cov=yapapi --ignore tests/goth_tests"
 goth-assets = "python -m goth create-assets tests/goth_tests/assets"
-goth-tests = "pytest -svx tests/goth_tests --reruns 3 --only-rerun AssertionError --only-rerun TimeoutError --only-rerun goth.runner.exceptions.TemporalAssertionError"
+goth-tests = "pytest -svx tests/goth_tests --reruns 3 --only-rerun AssertionError --only-rerun TimeoutError --only-rerun goth.runner.exceptions.TemporalAssertionError --only-rerun urllib.error.URLError"
 typecheck = "mypy ."
 codestyle = "black --check --diff ."
 _liccheck_export = "poetry export -E cli -f requirements.txt -o .requirements.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ ya-market = "0.1.0"
 [tool.poe.tasks]
 test = "pytest --cov=yapapi --ignore tests/goth_tests"
 goth-assets = "python -m goth create-assets tests/goth_tests/assets"
-goth-tests = "pytest -svx tests/goth_tests --reruns 3 --only-rerun AssertionError --only-rerun TimeoutError --only-rerun goth.runner.exceptions.TemporalAssertionError --only-rerun urllib.error.URLError"
+goth-tests = "pytest -svx tests/goth_tests --reruns 3 --only-rerun AssertionError --only-rerun TimeoutError --only-rerun goth.runner.exceptions.TemporalAssertionError --only-rerun urllib.error.URLError --only-rerun goth.runner.exceptions.CommandError"
 typecheck = "mypy ."
 codestyle = "black --check --diff ."
 _liccheck_export = "poetry export -E cli -f requirements.txt -o .requirements.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ integration-tests = ['goth', 'pytest', 'pytest-asyncio']
 [tool.poetry.dev-dependencies]
 black = "^21.7b0"
 pytest = "^6.2"
+pytest-rerunfailures = "^10.1"
 portray = "^1"
 pytest-asyncio = "^0.14"
 mypy = "^0.782"
@@ -109,7 +110,7 @@ ya-market = "0.1.0"
 [tool.poe.tasks]
 test = "pytest --cov=yapapi --ignore tests/goth_tests"
 goth-assets = "python -m goth create-assets tests/goth_tests/assets"
-goth-tests = "pytest -svx tests/goth_tests"
+goth-tests = "pytest -svx tests/goth_tests --reruns 3 --only-rerun AssertionError --only-rerun TimeoutError --only-rerun goth.runner.exceptions.TemporalAssertionError"
 typecheck = "mypy ."
 codestyle = "black --check --diff ."
 _liccheck_export = "poetry export -E cli -f requirements.txt -o .requirements.txt"

--- a/tests/goth_tests/conftest.py
+++ b/tests/goth_tests/conftest.py
@@ -1,4 +1,3 @@
-
 import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,12 +15,13 @@ from yapapi.package import vm
 #   Here we have a patch that is quite ugly, but hopefully harmless.
 class LoopThatIsNeverClosed(asyncio.AbstractEventLoop):
     """Just a loop, but if you try to use it after it was closed you use a fresh loop"""
+
     def __init__(self):
         self._loop = None
 
     def __getattribute__(self, name):
-        if name == '_loop':
-            return super().__getattribute__('_loop')
+        if name == "_loop":
+            return super().__getattribute__("_loop")
         if self._loop is None or self._loop._closed:
             self._loop = asyncio.new_event_loop()
         return getattr(self._loop, name)


### PR DESCRIPTION
Things I checked:
* random exceptions like `ZeroDivisionError` don't cause reruns
* failing `await wait_for_event(...)` causes reruns

--> this looks like the thing we need.

Unfortunately, a not-very-pretty hack was necessary to make this work. I think that this is acceptable, but I'm curious what others think.

Other options and general research summary are in https://github.com/golemfactory/goth/issues/545