### PR TITLE
.log, .png, .coverage and goth assets in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@ __pycache__/
 .idea
 *.egg-info
 
+#   files created by tests and examples
+*.log
+*.png
+.coverage
+
+tests/goth_tests/assets/
+
 dist/
 poetry.lock
 


### PR DESCRIPTION
resolves #637 