### PR TITLE
Ctrl+C stops Golem even with multiple `execute_tasks`

### DIFF
--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -270,6 +270,7 @@ class Executor:
             }
         )
         cancelled = False
+        cancelled_by = None
 
         try:
             while wait_until_done in services or not done_queue.empty():
@@ -314,9 +315,10 @@ class Executor:
 
             self.emit(events.ComputationFinished(job.id))
 
-        except (Exception, CancelledError, KeyboardInterrupt):
+        except (Exception, CancelledError, KeyboardInterrupt) as e:
             self.emit(events.ComputationFinished(job.id, exc_info=sys.exc_info()))  # type: ignore
             cancelled = True
+            cancelled_by = e
 
         finally:
 
@@ -371,6 +373,9 @@ class Executor:
                 logger.debug(
                     "Got error when waiting for services to finish", exc_info=True, job_id=job.id
                 )
+
+        if cancelled:
+            raise cast(BaseException, cancelled_by)
 
     async def _perform_implicit_init(self, ctx, job_id, agreement_id, activity):
         async def implicit_init():

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -313,10 +313,15 @@ class Executor:
                     get_done_task = None
 
             self.emit(events.ComputationFinished(job.id))
-
-        except (Exception, KeyboardInterrupt):
+        except (Exception, CancelledError, KeyboardInterrupt) as e:
+            #   TODO: why do we catch KeyboardInterrupt? How can we get one here?
             self.emit(events.ComputationFinished(job.id, exc_info=sys.exc_info()))  # type: ignore
             cancelled = True
+
+            if isinstance(e, CancelledError):
+                #   CancelledError is an "external" error, not caused by the Executor internals ->
+                #   we don't want to suppress it here
+                raise
 
         finally:
 

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -314,7 +314,7 @@ class Executor:
 
             self.emit(events.ComputationFinished(job.id))
 
-        except (Exception, CancelledError, KeyboardInterrupt):
+        except (Exception, KeyboardInterrupt):
             self.emit(events.ComputationFinished(job.id, exc_info=sys.exc_info()))  # type: ignore
             cancelled = True
 

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -270,7 +270,6 @@ class Executor:
             }
         )
         cancelled = False
-        cancelled_by = None
 
         try:
             while wait_until_done in services or not done_queue.empty():
@@ -315,10 +314,9 @@ class Executor:
 
             self.emit(events.ComputationFinished(job.id))
 
-        except (Exception, CancelledError, KeyboardInterrupt) as e:
+        except (Exception, CancelledError, KeyboardInterrupt):
             self.emit(events.ComputationFinished(job.id, exc_info=sys.exc_info()))  # type: ignore
             cancelled = True
-            cancelled_by = e
 
         finally:
 
@@ -373,9 +371,6 @@ class Executor:
                 logger.debug(
                     "Got error when waiting for services to finish", exc_info=True, job_id=job.id
                 )
-
-        if cancelled:
-            raise cast(BaseException, cancelled_by)
 
     async def _perform_implicit_init(self, ctx, job_id, agreement_id, activity):
         async def implicit_init():

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -313,6 +313,7 @@ class Executor:
                     get_done_task = None
 
             self.emit(events.ComputationFinished(job.id))
+
         except (Exception, CancelledError, KeyboardInterrupt) as e:
             #   TODO: why do we catch KeyboardInterrupt? How can we get one here?
             self.emit(events.ComputationFinished(job.id, exc_info=sys.exc_info()))  # type: ignore


### PR DESCRIPTION
resolves https://github.com/golemfactory/yapapi/issues/738

NOTE:
1. I did only a little testing, but this looks like a sort-of-safe change. The main question is: how can we get a `CancelledError` here, and is there any situation when we really don't want to rereiase it?
2. Now after `Ctrl+C` we have `Error when shutting down Golem engine: CancelledError()` and this is exactly the same case as in simple service -> https://github.com/golemfactory/yapapi/issues/714. This is sort-of-nice because we really **want** the same behavior in task/service API.
3. I added 5 lines to a function that already was over 200 lines long. I don't feel very good with this, but I guess refactoring is a **really complex** issue here (also I think it should be done).