### PR TITLE
ExecutionInterrupted event in engine.stop

### DIFF
--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -229,8 +229,8 @@ class _Engine:
 
         This *must* be called at the end of the work, by the Engine user.
         """
-        if exc_info:
-            self.emit(events.ExecutionInterrupted(exc_info))
+        if exc_info[0] is not None:
+            self.emit(events.ExecutionInterrupted(exc_info))  # type: ignore
         return await self._stack.__aexit__(None, None, None)
 
     async def start(self):

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -229,7 +229,9 @@ class _Engine:
 
         This *must* be called at the end of the work, by the Engine user.
         """
-        return await self._stack.__aexit__(*exc_info)
+        if exc_info:
+            self.emit(events.ExecutionInterrupted(exc_info))
+        return await self._stack.__aexit__(None, None, None)
 
     async def start(self):
         """Start the engine.

--- a/yapapi/events.py
+++ b/yapapi/events.py
@@ -280,6 +280,11 @@ class ShutdownFinished(HasExcInfo):
 
 
 @dataclass
+class ExecutionInterrupted(HasExcInfo):
+    """Emitted when Golem was stopped by an unhandled exception in code not managed by yapapi"""
+
+
+@dataclass
 class CommandEventContext:
     evt_cls: Type[CommandEvent]
     kwargs: dict

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -176,6 +176,7 @@ event_type_to_string = {
     events.DownloadStarted: "Download started",
     events.DownloadFinished: "Download finished",
     events.ShutdownFinished: "Shutdown finished",
+    events.ExecutionInterrupted: "Execution interrupted",
 }
 
 
@@ -606,6 +607,11 @@ class SummaryLogger:
             else:
                 prov_info = self.agreement_provider_info[event.agr_id]
                 self.logger.info(f"Terminated agreement with {prov_info.name}", job_id=event.job_id)
+
+        elif isinstance(event, events.ExecutionInterrupted):
+            assert event.exc_info
+            exc_type = event.exc_info[0]
+            self.logger.warning(f"Execution interrupted by {exc_type.__name__}")
 
 
 def log_summary(wrapped_emitter: Optional[Callable[[events.Event], None]] = None):


### PR DESCRIPTION
This resolves #714 - there is quite a lot of mess in this task, so a short summary:

Sometimes `Golem.__aexit__` is caused by an exception. Two examples:
1. Add in line 135 in `blender.py` some exception, e.g.:
    ```
    async for task in completed_tasks:
        print(task.OOPS_NOTHING_HERE)
    ```
2. Run `simple_service.py` example and press ctrl+C when you see "All instances started :)"

These are exceptions **not** handled by `yapapi` in any way: this is just pure-python "exception -> jump to aexit". Currently, they are reported as "Error when shutting down Golem engine". This is clearly wrong & we're fixing it here. 

I add a new event. There are probably other solutions possible, but I think this is a "valuable" event-like information that could be useful also for some non-default event consumer. Default logger prints a single line about execution being interrupted (and details/tracebak are in the log file).