### PR TITLE
Set min-cpu-threads to 1 in blender

### DIFF
--- a/examples/blender/blender.py
+++ b/examples/blender/blender.py
@@ -152,7 +152,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--min-cpu-threads",
         type=int,
-        default=2,
+        default=1,
         help="require the provider nodes to have at least this number of available CPU threads",
     )
     now = datetime.now().strftime("%Y-%m-%d_%H.%M.%S")


### PR DESCRIPTION
Reasons:
1. @shadeofblue fell in a "I have no offers from my own provider" trap
2. Scenario "run interactive `goth`, and `python3 blender.py --subnet-tag goth`" doesn't work anymore (and it's quite hard to guess where's the problem)