### PR TITLE
ComputationStarted/Finished in services API

### DIFF
--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -163,8 +163,6 @@ class Executor:
         job: Job,
     ) -> AsyncGenerator[Task[D, R], None]:
 
-        self.emit(events.ComputationStarted(job.id, job.expiration_time))
-
         done_queue: asyncio.Queue[Task[D, R]] = asyncio.Queue()
 
         def on_task_done(task: Task[D, R], status: TaskStatus) -> None:
@@ -312,11 +310,9 @@ class Executor:
                     assert get_done_task not in services
                     get_done_task = None
 
-            self.emit(events.ComputationFinished(job.id))
-
         except (Exception, CancelledError, KeyboardInterrupt) as e:
             #   TODO: why do we catch KeyboardInterrupt? How can we get one here?
-            self.emit(events.ComputationFinished(job.id, exc_info=sys.exc_info()))  # type: ignore
+            job.set_exc_info(sys.exc_info())
             cancelled = True
 
             if isinstance(e, CancelledError):

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -545,6 +545,9 @@ class Cluster(AsyncContextManager):
 
         logger.debug("%s is shutting down...", self)
 
+        if exc_type is not None:
+            self.job.set_exc_info((exc_type, exc_val, exc_tb))
+
         # Give the instance tasks some time to terminate gracefully.
         # Then cancel them without mercy!
         if self._instance_tasks:


### PR DESCRIPTION
NOTES:
1. Those events are emitted now in `_Engine` and are tightly connected to the `Engine/Job` interaction. I think this is a change for better.
2. I'd love to drop ugly `_exc_info/set_exc_info()` from `Job` object (`exc_info` could be just passed to `Engine.finalize_job`), but this requires one of:
    * more serious refactoring in `Executor` and I'd rather not do it
    * `Executor._exc_info` and this also seems ugly (although maybe better?)
3. I'm not super sure about this PR. Please be meticulous.