### PR TITLE
Recycle offer from a rejected agreement

### DIFF
--- a/tests/test_agreements_pool.py
+++ b/tests/test_agreements_pool.py
@@ -24,6 +24,13 @@ def mock_agreement(**properties):
     return create_agreement
 
 
+def recycle_offer_cb(offer):
+    """AgreementsPool.use_agreement() sometimes initiates recycling of offers.
+
+    This has nothing to do with the things we test here, but is required by the interface"""
+    pass
+
+
 @pytest.mark.asyncio
 async def test_use_agreement_chooses_max_score():
     """Test that a proposal with the largest score is chosen in AgreementsPool.use_agreement()."""
@@ -48,7 +55,7 @@ async def test_use_agreement_chooses_max_score():
         return True
 
     for _ in proposals.items():
-        await pool.use_agreement(use_agreement_cb)
+        await pool.use_agreement(use_agreement_cb, recycle_offer_cb)
 
     # Make sure that proposals are chosen according to the decreasing ordering of the scores
     sorted_scores = sorted((score for score, _ in proposals.values()), reverse=True)
@@ -82,7 +89,7 @@ async def test_use_agreement_shuffles_proposals():
             chosen_proposal_ids.add(agreement.proposal_id)
             return True
 
-        await pool.use_agreement(use_agreement_cb)
+        await pool.use_agreement(use_agreement_cb, recycle_offer_cb)
 
     # Make sure that each proposal id with the highest score has been chosen
     assert chosen_proposal_ids == {n for n in all_proposal_ids if n != 0}
@@ -97,5 +104,5 @@ async def test_use_agreement_no_proposals():
     def use_agreement_cb(_agreement):
         assert False, "use_agreement callback called"
 
-    result = await pool.use_agreement(use_agreement_cb)
+    result = await pool.use_agreement(use_agreement_cb, recycle_offer_cb)
     assert result is None

--- a/yapapi/agreements_pool.py
+++ b/yapapi/agreements_pool.py
@@ -74,9 +74,9 @@ class AgreementsPool:
     async def use_agreement(
         self,
         agreement_cbk: Callable[[Agreement, AgreementDetails], asyncio.Task],
-        recycle_offer_cbk: Callable[[OfferProposal], None]
+        recycle_offer_cbk: Callable[[OfferProposal], None],
     ) -> Optional[asyncio.Task]:
-        """Get an agreement and start the `cbk()` task within it."""
+        """Get an agreement and start the `agreement_cbk()` task within it."""
         async with self._lock:
             agreement_with_info = await self._get_agreement(recycle_offer_cbk)
             if agreement_with_info is None:
@@ -95,8 +95,7 @@ class AgreementsPool:
         buffered_agreement.worker_task = task
 
     async def _get_agreement(
-        self,
-        recycle_offer_cbk: Callable[[OfferProposal], None]
+        self, recycle_offer_cbk: Callable[[OfferProposal], None]
     ) -> Optional[Tuple[Agreement, AgreementDetails]]:
         """Returns an Agreement
 

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -681,6 +681,7 @@ class _Engine:
 
         We don't care which Job initiated recycling - it should be recycled by all unfinished Jobs.
         """
+
         async def handle_proposal(job):
             event = await job._handle_proposal(offer, ignore_draft=True)
             self.emit(event)


### PR DESCRIPTION
Resolves https://github.com/golemfactory/yagna-triage/issues/156

Commits are a mess. Code should be clear.

One explanation: everything around `DemandBuilder` should work like before, but now it's an attribute, not something passed from function to function, so we can call `_handle_proposal` also from other parts of the code.