### PR TITLE
Add `Agreement` to WorkContext

### DIFF
--- a/tests/factories/context.py
+++ b/tests/factories/context.py
@@ -9,5 +9,5 @@ class WorkContextFactory(factory.Factory):
         model = WorkContext
 
     activity = mock.MagicMock()
-    agreement_details = mock.MagicMock()
+    agreement = mock.MagicMock()
     storage = mock.AsyncMock()

--- a/tests/test_agreements_pool.py
+++ b/tests/test_agreements_pool.py
@@ -43,7 +43,7 @@ async def test_use_agreement_chooses_max_score():
 
     chosen_proposal_ids = []
 
-    def use_agreement_cb(agreement, _node_info):
+    def use_agreement_cb(agreement):
         chosen_proposal_ids.append(agreement.proposal_id)
         return True
 
@@ -78,7 +78,7 @@ async def test_use_agreement_shuffles_proposals():
         for score, proposal in proposals:
             await pool.add_proposal(score, proposal)
 
-        def use_agreement_cb(agreement, _node_info):
+        def use_agreement_cb(agreement):
             chosen_proposal_ids.add(agreement.proposal_id)
             return True
 

--- a/yapapi/agreements_pool.py
+++ b/yapapi/agreements_pool.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 import random
 import sys
-from typing import Dict, NamedTuple, Optional, Set, Tuple, Callable
+from typing import Dict, NamedTuple, Optional, Set, Callable
 
 import aiohttp
 
@@ -78,15 +78,14 @@ class AgreementsPool:
             )
 
     async def use_agreement(
-        self, cbk: Callable[[Agreement, AgreementDetails], asyncio.Task]
+        self, cbk: Callable[[Agreement], asyncio.Task]
     ) -> Optional[asyncio.Task]:
         """Get an agreement and start the `cbk()` task within it."""
         async with self._lock:
-            agreement_with_info = await self._get_agreement()
-            if agreement_with_info is None:
+            agreement = await self._get_agreement()
+            if agreement is None:
                 return None
-            agreement, agreement_details = agreement_with_info
-            task = cbk(agreement, agreement_details)
+            task = cbk(agreement)
             await self._set_worker(agreement.id, task)
             return task
 
@@ -98,7 +97,7 @@ class AgreementsPool:
         assert buffered_agreement.worker_task is None
         buffered_agreement.worker_task = task
 
-    async def _get_agreement(self) -> Optional[Tuple[Agreement, AgreementDetails]]:
+    async def _get_agreement(self) -> Optional[Agreement]:
         """Returns an Agreement
 
         Firstly it tries to reuse agreement from a pool of available agreements
@@ -111,7 +110,7 @@ class AgreementsPool:
                 [ba for ba in self._agreements.values() if ba.worker_task is None]
             )
             logger.debug("Reusing agreement. id: %s", buffered_agreement.agreement.id)
-            return buffered_agreement.agreement, buffered_agreement.agreement_details
+            return buffered_agreement.agreement
         except IndexError:  # empty pool
             pass
 
@@ -171,7 +170,7 @@ class AgreementsPool:
         )
         emit(events.AgreementConfirmed(job_id=self.job_id, agr_id=agreement.id))
         self.confirmed += 1
-        return agreement, agreement_details
+        return agreement
 
     async def release_agreement(self, agreement_id: str, allow_reuse: bool = True) -> None:
         """Marks agreement as unused.

--- a/yapapi/ctx.py
+++ b/yapapi/ctx.py
@@ -15,7 +15,7 @@ from yapapi.events import CommandExecuted
 from yapapi.props.com import ComLinear
 from yapapi.script import Script
 from yapapi.storage import StorageProvider, DOWNLOAD_BYTES_LIMIT_DEFAULT
-from yapapi.rest.market import AgreementDetails
+from yapapi.rest.market import Agreement, AgreementDetails
 from yapapi.rest.activity import Activity
 from yapapi.script.command import StorageEvent
 from yapapi.utils import get_local_timezone
@@ -83,12 +83,12 @@ class WorkContext:
     def __init__(
         self,
         activity: Activity,
-        agreement_details: AgreementDetails,
+        agreement: Agreement,
         storage: StorageProvider,
         emitter: Optional[Callable[[StorageEvent], None]] = None,
     ):
         self._activity = activity
-        self._agreement_details = agreement_details
+        self._agreement = agreement
         self._storage: StorageProvider = storage
         self._emitter: Optional[Callable[[StorageEvent], None]] = emitter
 
@@ -128,6 +128,10 @@ class WorkContext:
             self.__payment_model = self._agreement_details.provider_view.extract(ComLinear)
 
         return self.__payment_model
+
+    @property
+    def _agreement_details(self) -> AgreementDetails:
+        return self._agreement.cached_details
 
     def new_script(
         self, timeout: Optional[timedelta] = None, wait_for_results: bool = True

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -582,9 +582,8 @@ class _Engine:
 
             async with activity:
                 self.accept_debit_notes_for_agreement(job.id, agreement.id)
-                agreement_details = await agreement.details()
                 work_context = WorkContext(
-                    activity, agreement_details, self.storage_manager, emitter=self.emit
+                    activity, agreement, self.storage_manager, emitter=self.emit
                 )
                 await run_worker(agreement, activity, work_context)
 

--- a/yapapi/executor/__init__.py
+++ b/yapapi/executor/__init__.py
@@ -17,10 +17,9 @@ from typing import (
 )
 from typing_extensions import Final, AsyncGenerator
 
-from yapapi import rest, events
+from yapapi import events
 from yapapi.ctx import WorkContext
 from yapapi.payload import Payload
-from yapapi.rest.activity import Activity
 from yapapi.script import Script
 from yapapi.engine import _Engine, Job
 from yapapi.script.command import Deploy, Start
@@ -182,10 +181,10 @@ class Executor:
 
         work_queue = SmartQueue(input_tasks())
 
-        async def run_worker(
-            agreement: rest.market.Agreement, activity: Activity, work_context: WorkContext
-        ) -> None:
-            """Run an instance of `worker` for the particular activity and work context."""
+        async def run_worker(work_context: WorkContext) -> None:
+            """Run an instance of `worker` for the particular work context."""
+            agreement = work_context._agreement
+            activity = work_context._activity
 
             with work_queue.new_consumer() as consumer:
                 try:

--- a/yapapi/rest/market.py
+++ b/yapapi/rest/market.py
@@ -77,6 +77,17 @@ class Agreement(object):
             self._details = AgreementDetails(_ref=await self._api.get_agreement(self._id))
         return self._details
 
+    @property
+    def cached_details(self) -> AgreementDetails:
+        """Return cached details after prior call to `await self.details()` or raise RuntimeError.
+
+        The only purpose is to provide a sync interface to the details."""
+        if not self._details:
+            raise RuntimeError(
+                "Method cached_details() can be called only after prior `await details()`"
+            )
+        return self._details
+
     async def confirm(self) -> bool:
         """Sign and send the agreement to the provider and then wait for it to be approved.
 

--- a/yapapi/services.py
+++ b/yapapi/services.py
@@ -34,12 +34,12 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Final
 
-from yapapi import rest, events
+from yapapi import events
 from yapapi.ctx import WorkContext
 from yapapi.engine import _Engine, Job
 from yapapi.network import Network, Node
 from yapapi.payload import Payload
-from yapapi.rest.activity import Activity, BatchError
+from yapapi.rest.activity import BatchError
 from yapapi.script import Script
 
 
@@ -769,10 +769,12 @@ class Cluster(AsyncContextManager):
         instance: Optional[ServiceInstance] = None
         agreement_id: Optional[str]  # set in start_worker
 
-        async def _worker(
-            agreement: rest.market.Agreement, activity: Activity, work_context: WorkContext
-        ) -> None:
+        async def _worker(work_context: WorkContext) -> None:
             nonlocal agreement_id, instance
+
+            agreement = work_context._agreement
+            activity = work_context._activity
+
             agreement_id = agreement.id
 
             task_id = f"{self.id}:{next(self._task_ids)}"


### PR DESCRIPTION
Closes #776. Solution described in the issue is **not** implemented, but the "real" need (an object that is widely available and knows both Activity and Agreement) is satisfied with modifications to WorkContext.

Thanks to the a little refactoring we have a total 3 arguments less in a few pretty complex functions.

It's **strongly recommended** to consume this PR single commit at a time (since commits are pretty clean and separate).