### PR TITLE
type hints for service instances spawned within a cluster et al

### DIFF
--- a/examples/simple-service-poc/simple_service.py
+++ b/examples/simple-service-poc/simple_service.py
@@ -144,11 +144,17 @@ async def main(
 
         print(f"{TEXT_COLOR_YELLOW}" f"Starting {cluster}..." f"{TEXT_COLOR_DEFAULT}")
 
-        def instances():
-            return [
-                f"{s.name}: {s.state.value}" + (f" on {s.provider_name}" if s.provider_id else "")
-                for s in cluster.instances
-            ]
+        def print_instances():
+            print(
+                f"instances: "
+                + str(
+                    [
+                        f"{s.name}: {s.state.value}"
+                        + (f" on {s.provider_name}" if s.provider_id else "")
+                        for s in cluster.instances
+                    ]
+                )
+            )
 
         def still_starting():
             return any(
@@ -158,7 +164,7 @@ async def main(
         # wait until instances are started
 
         while still_starting() and datetime.now() < commissioning_time + STARTING_TIMEOUT:
-            print(f"instances: {instances()}")
+            print_instances()
             await asyncio.sleep(5)
 
         if still_starting():
@@ -172,7 +178,7 @@ async def main(
         start_time = datetime.now()
 
         while datetime.now() < start_time + timedelta(seconds=running_time):
-            print(f"instances: {instances()}")
+            print_instances()
             await asyncio.sleep(5)
 
         print(f"{TEXT_COLOR_YELLOW}Stopping {cluster}...{TEXT_COLOR_DEFAULT}")
@@ -182,10 +188,10 @@ async def main(
 
         cnt = 0
         while cnt < 10 and any(s.is_available for s in cluster.instances):
-            print(f"instances: {instances()}")
+            print_instances()
             await asyncio.sleep(5)
 
-    print(f"instances: {instances()}")
+    print_instances()
 
 
 if __name__ == "__main__":

--- a/tests/goth_tests/test_power_outage.py
+++ b/tests/goth_tests/test_power_outage.py
@@ -84,7 +84,7 @@ async def test_power_outage(
             logger.info("Agreement confirmed")
 
             await cmd_monitor.wait_for_pattern(
-                ".*Task started on provider 'provider-1'.*", timeout=10
+                ".*Task started on provider 'provider-1'.*", timeout=20
             )
 
             logger.debug("Stopping provider 1")

--- a/tests/goth_tests/test_run_simple_service.py
+++ b/tests/goth_tests/test_run_simple_service.py
@@ -58,7 +58,9 @@ async def test_run_simple_service(
             cmd_monitor.add_assertion(assert_no_errors)
             cmd_monitor.add_assertion(assert_all_invoices_accepted)
 
-            await cmd_monitor.wait_for_pattern("Starting 1 instance", timeout=20)
+            await cmd_monitor.wait_for_pattern(
+                "Starting Cluster 1: 1x\\[Service: SimpleService", timeout=20
+            )
             # A longer timeout to account for downloading a VM image
             await cmd_monitor.wait_for_pattern("All instances started", timeout=120)
             logger.info(f"The instance was started successfully ({elapsed_time()})")
@@ -67,7 +69,9 @@ async def test_run_simple_service(
                 await cmd_monitor.wait_for_pattern("instances:.*running", timeout=20)
                 logger.info("The instance is running")
 
-            await cmd_monitor.wait_for_pattern("Stopping instances", timeout=60)
+            await cmd_monitor.wait_for_pattern(
+                "Stopping Cluster 1: 1x\\[Service: SimpleService", timeout=60
+            )
             logger.info(f"The instance is stopping ({elapsed_time()})")
 
             await cmd_monitor.wait_for_pattern(".*All jobs have finished", timeout=20)

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -28,7 +28,7 @@ from yapapi.executor.task import Task
 from yapapi.network import Network
 from yapapi.payload import Payload
 from yapapi.script import Script
-from yapapi.services import Cluster, Service
+from yapapi.services import Cluster, Service, ServiceType
 from yapapi.utils import warn_deprecated, Deprecated
 
 if TYPE_CHECKING:
@@ -283,7 +283,7 @@ class Golem:
 
     async def run_service(
         self,
-        service_class: Type[Service],
+        service_class: Type[ServiceType],
         num_instances: Optional[int] = None,
         instance_params: Optional[Iterable[Dict]] = None,
         payload: Optional[Payload] = None,
@@ -291,7 +291,7 @@ class Golem:
         respawn_unstarted_instances=True,
         network: Optional[Network] = None,
         network_addresses: Optional[List[str]] = None,
-    ) -> Cluster:
+    ) -> Cluster[ServiceType]:
         """Run a number of instances of a service represented by a given :class:`~yapapi.services.Service` subclass.
 
         :param service_class: a subclass of :class:`~yapapi.services.Service` that represents the service to be run

--- a/yapapi/services/__init__.py
+++ b/yapapi/services/__init__.py
@@ -1,4 +1,4 @@
 from .cluster import Cluster, MAX_AGREEMENT_EXPIRATION, MIN_AGREEMENT_EXPIRATION
-from .service import Service, ServiceInstance
+from .service import Service, ServiceInstance, ServiceType
 from .service_state import ServiceState
 from .service_runner import ServiceRunner

--- a/yapapi/services/cluster.py
+++ b/yapapi/services/cluster.py
@@ -6,6 +6,7 @@ from typing import (
     AsyncContextManager,
     Dict,
     Generator,
+    Generic,
     Iterable,
     List,
     Optional,
@@ -23,7 +24,7 @@ from yapapi.network import Network
 from yapapi.payload import Payload
 from yapapi.engine import _Engine, Job
 
-from .service import Service
+from .service import Service, ServiceType
 from .service_runner import ServiceRunner
 
 # current defaults for yagna providers as of yagna 0.6.x, see
@@ -33,13 +34,13 @@ MAX_AGREEMENT_EXPIRATION: Final[timedelta] = timedelta(minutes=180)
 DEFAULT_SERVICE_EXPIRATION: Final[timedelta] = MAX_AGREEMENT_EXPIRATION - timedelta(minutes=5)
 
 
-class Cluster(AsyncContextManager):
+class Cluster(AsyncContextManager, Generic[ServiceType]):
     """Golem's sub-engine used to spawn and control instances of a single :class:`Service`."""
 
     def __init__(
         self,
         engine: _Engine,
-        service_class: Type[Service],
+        service_class: Type[ServiceType],
         payload: Payload,
         expiration: Optional[datetime] = None,
         respawn_unstarted_instances: bool = True,
@@ -104,7 +105,7 @@ class Cluster(AsyncContextManager):
         return self.service_runner._job.payload
 
     @property
-    def service_class(self) -> Type[Service]:
+    def service_class(self) -> Type[ServiceType]:
         """Return the class instantiated by all service instances in this :class:`Cluster`."""
         return self._service_class
 
@@ -115,16 +116,16 @@ class Cluster(AsyncContextManager):
 
     def __repr__(self):
         return (
-            f"Cluster {self.id}: {len(self.__instances)}x[Service: {self._service_class.__name__}, "
-            f"Payload: {self._payload}]"
+            f"Cluster {self.id}: {len(self.instances)}x[Service: {self._service_class.__name__}, "
+            f"Payload: {self.payload}]"
         )
 
     @property
-    def instances(self) -> List[Service]:
+    def instances(self) -> List[ServiceType]:
         """Return the list of service instances in this :class:`Cluster`."""
         return self.service_runner.instances.copy()
 
-    def stop_instance(self, service: Service):
+    def stop_instance(self, service: ServiceType):
         """Stop the specific :class:`Service` instance belonging to this :class:`Cluster`."""
         self.service_runner.stop_instance(service)
 

--- a/yapapi/services/cluster.py
+++ b/yapapi/services/cluster.py
@@ -24,7 +24,7 @@ from yapapi.network import Network
 from yapapi.payload import Payload
 from yapapi.engine import _Engine, Job
 
-from .service import Service, ServiceType
+from .service import ServiceType
 from .service_runner import ServiceRunner
 
 # current defaults for yagna providers as of yagna 0.6.x, see
@@ -169,7 +169,7 @@ class Cluster(AsyncContextManager, Generic[ServiceType]):
             service._set_cluster(self)
 
     @staticmethod
-    def _instance_not_started(service: Service) -> bool:
+    def _instance_not_started(service: ServiceType) -> bool:
         return (
             service.exc_info() != (None, None, None)
             and not service.service_instance.started_successfully

--- a/yapapi/services/service.py
+++ b/yapapi/services/service.py
@@ -12,6 +12,7 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    TypeVar,
     TYPE_CHECKING,
     Union,
 )
@@ -385,6 +386,9 @@ class Service:
     @property
     def service_instance(self):
         return self.__service_instance
+
+
+ServiceType = TypeVar("ServiceType", bound=Service)
 
 
 @dataclass

--- a/yapapi/services/service_runner.py
+++ b/yapapi/services/service_runner.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 from yapapi import events
 
-from .service import Service, ServiceInstance
+from .service import Service, ServiceType, ServiceInstance
 from .service_state import ServiceState
 from yapapi.ctx import WorkContext
 from yapapi.rest.activity import BatchError
@@ -59,10 +59,10 @@ class ServiceRunner(AsyncContextManager):
 
     def add_instance(
         self,
-        service: Service,
+        service: ServiceType,
         network: Optional[Network] = None,
         network_address: Optional[str] = None,
-        respawn_condition: Optional[Callable[[Service], bool]] = None,
+        respawn_condition: Optional[Callable[[ServiceType], bool]] = None,
     ) -> None:
         """Add service the the collection of services managed by this ServiceRunner.
 
@@ -309,10 +309,10 @@ class ServiceRunner(AsyncContextManager):
 
     async def spawn_instance(
         self,
-        service: Service,
+        service: ServiceType,
         network: Optional[Network] = None,
         network_address: Optional[str] = None,
-        respawn_condition: Optional[Callable[[Service], bool]] = None,
+        respawn_condition: Optional[Callable[[ServiceType], bool]] = None,
     ) -> None:
         """Lifecycle the service within this :class:`ServiceRunner`.
 
@@ -398,7 +398,7 @@ class ServiceRunner(AsyncContextManager):
                     logger.error("Failed to spawn instance", exc_info=True)
                     return
 
-    async def _ensure_payload_matches(self, service):
+    async def _ensure_payload_matches(self, service: Service):
         #   Possible improvement: maybe we should accept services with lower demands then our payload?
         #   E.g. if service expects 2GB and we have 4GB in our payload, then this seems fine.
         #   (Not sure how much effort this requires)


### PR DESCRIPTION
* fix type hints for service instances spawned within a cluster
* fix `Cluster`'s `__repr__`
* reinstate usage of an assigned custom initialization parameter

closes #445 