### PR TITLE
Change exception interface for events

### DIFF
--- a/tests/goth_tests/test_agreement_termination/test_agreement_termination.py
+++ b/tests/goth_tests/test_agreement_termination/test_agreement_termination.py
@@ -21,7 +21,7 @@ async def assert_command_error(stream):
     """Assert that a worker failure due to `CommandExecutionError` is reported."""
 
     async for line in stream:
-        m = re.match(r"WorkerFinished\(.*agr_id='([^']+)'.*CommandExecutionError", line)
+        m = re.match(r"WorkerFinished\(.*CommandExecutionError.*agr_id='([^']+)'.*", line)
         if m:
             return m.group(1)
     raise AssertionError("Expected CommandExecutionError failure")

--- a/tests/goth_tests/test_multiactivity_agreement/test_multiactivity_agreement.py
+++ b/tests/goth_tests/test_multiactivity_agreement/test_multiactivity_agreement.py
@@ -39,7 +39,7 @@ async def assert_multiple_workers_run(agr_id, events):
         if m:
             worker_agr_id = m.group(1)
             assert worker_agr_id == agr_id, "Worker run for another agreement"
-            assert line.endswith(" exc_info=None)"), "Worker finished with error"
+            assert "exc_info=None" in line, "Worker finished with error"
             workers_finished += 1
         elif re.match("ComputationFinished", line):
             break

--- a/tests/test_add_event_consumer.py
+++ b/tests/test_add_event_consumer.py
@@ -5,9 +5,14 @@ from yapapi import Golem, events
 
 sample_events = [
     events.CollectFailed("foo", "bar"),
-    events.TaskStarted("job_id", "agreement_id", "task_id", [{"some": "data"}]),
+    events.TaskStarted(
+        task_data=[{"some": "data"}],
+        task_id="task_id",
+        job_id="job_id",
+        agr_id="agreement_id",
+    ),
 ]
-emitted_events = sample_events + [events.ShutdownFinished(exc_info=None)]
+emitted_events = sample_events + [events.ShutdownFinished()]
 
 
 @pytest.mark.asyncio

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -235,7 +235,7 @@ class _Engine:
         This *must* be called at the end of the work, by the Engine user.
         """
         if exc_info[0] is not None:
-            self.emit(events.ExecutionInterrupted(exc_info))  # type: ignore
+            self.emit(events.ExecutionInterrupted())
         return await self._stack.__aexit__(None, None, None)
 
     async def start(self):

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -235,7 +235,7 @@ class _Engine:
         This *must* be called at the end of the work, by the Engine user.
         """
         if exc_info[0] is not None:
-            self.emit(events.ExecutionInterrupted())
+            self.emit(events.ExecutionInterrupted(exc_info=exc_info))  # type: ignore
         return await self._stack.__aexit__(None, None, None)
 
     async def start(self):


### PR DESCRIPTION
Key changes:
1. Flattened the event hierarchy by removing the class `HasExcInfo`.
2. Added public attributes `exception` and `exc_info` to the base
   `Event` class.
3. Reworked the class hierarchy for events by replacing dataclasses
   usage with attr and making intermediate base classes (e.g. `JobEvent`)
   abstract.