### PR TITLE
Don't try to create a list of all tasks in yacat

### DIFF
--- a/examples/yacat/yacat.py
+++ b/examples/yacat/yacat.py
@@ -183,7 +183,7 @@ async def main(args):
             f"{TEXT_COLOR_DEFAULT}"
         )
 
-        data = [Task(data=c) for c in range(0, keyspace, args.chunk_size)]
+        data = (Task(data=c) for c in range(0, keyspace, args.chunk_size))
         max_workers = args.max_workers or math.ceil(keyspace / args.chunk_size) // 2
 
         completed = golem.execute_tasks(


### PR DESCRIPTION
Fix `yacat` eating to much RAM when the keyspace is very big, e.g.

```
python yacat.py --mask '?a?a?a?a?a?a?a?a' --hash '$H$5ZDzPE45Ci.QxPaPz.03z6TYbakcSQ0' --max-workers 10 --chunk-size 20000
```

Maybe we'd like to add some warning here as well? Like "you have 21837465123512875 tasks, this will run very long"?