### PR TITLE
fix workcontext factory mocks

### DIFF
--- a/tests/factories/context.py
+++ b/tests/factories/context.py
@@ -13,7 +13,7 @@ class WorkContextFactory(factory.Factory):
     class Meta:
         model = WorkContext
 
-    activity = mock.MagicMock()
-    agreement = mock.MagicMock()
-    storage = mock.AsyncMock()
+    activity = factory.LazyFunction(mock.MagicMock)
+    agreement = factory.LazyFunction(mock.MagicMock)
+    storage = factory.LazyFunction(mock.AsyncMock)
     emitter = mock_emitter


### PR DESCRIPTION
mocks in factories should not be instantiated on the Factory class but rather on generated instances

see:
https://factoryboy.readthedocs.io/en/stable/reference.html?highlight=lazyfunction#lazyfunction