### PR TITLE
Bump python version in readthedocs config to 3.8

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-  version: "3.7"
+  version: "3.8"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
As far as I remember there was **no** reason for 3.7, it was just
a first default copied from somewhere.