### PR TITLE
yapapi.get_version() in sphinx conf

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -15,6 +15,8 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../../"))
 
+from yapapi import get_version
+
 
 # -- Project information -----------------------------------------------------
 
@@ -23,7 +25,7 @@ copyright = "2020-2021, Golem Factory"
 author = "Golem Factory"
 
 # The full version, including alpha/beta/rc tags
-release = "0.7.0"
+release = get_version()
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This `version` is used only (I think?) in the html title: 
```
<title>Golem Python API Reference &mdash; yapapi 0.8.0 documentation</title>
```