### PR TITLE
Accept multiple debit notes concurrently

### DIFF
--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -462,9 +462,9 @@ class _Engine:
         debit_note_processing_tasks = []
         loop = asyncio.get_event_loop()
 
-        async for debit_note in self._payment_api.incoming_debit_notes():
+        async for debit_note_id in self._payment_api.incoming_debit_note_ids():
             debit_note_processing_tasks.append(
-                loop.create_task(self._process_debit_note(debit_note))
+                loop.create_task(self._process_debit_note(debit_note_id))
             )
             if self._payment_closing and not self._agreements_to_pay:
                 break
@@ -472,7 +472,8 @@ class _Engine:
         if debit_note_processing_tasks:
             await asyncio.gather(*debit_note_processing_tasks)
 
-    async def _process_debit_note(self, debit_note: rest.payment.DebitNote) -> None:
+    async def _process_debit_note(self, debit_note_id: str) -> None:
+        debit_note = await self._payment_api.debit_note(debit_note_id)
         job_id = next(
             (
                 id

--- a/yapapi/rest/payment.py
+++ b/yapapi/rest/payment.py
@@ -239,7 +239,7 @@ class Payment(object):
 
         return fetch(ts)
 
-    def incoming_debit_notes(self) -> AsyncIterator[DebitNote]:
+    def incoming_debit_note_ids(self) -> AsyncIterator[str]:
         ts = datetime.now(timezone.utc)
 
         async def fetch(init_ts: datetime):
@@ -255,8 +255,7 @@ class Payment(object):
                         if not ev.debit_note_id:
                             logger.error("Empty debit note id in event: %r", ev)
                             continue
-                        debit_note = await self.debit_note(ev.debit_note_id)
-                        yield debit_note
+                        yield ev.debit_note_id
                 if not events:
                     await asyncio.sleep(1)
 


### PR DESCRIPTION
@nieznanysprawiciel says there is a bottleneck in `yapapi` accepting debit notes. This might be related to troubles @filipgolem and @cryptobench recently had.

I guess this should help and be harmless, but I'm not sure -> please check carefully.
E.g. maybe we should limit the number of tasks created?

All three commits do different things.
