### PR TITLE
Temporarily disable SSH integration test

### DIFF
--- a/tests/goth_tests/test_run_ssh.py
+++ b/tests/goth_tests/test_run_ssh.py
@@ -25,6 +25,7 @@ SUBNET_TAG = "goth"
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="regression in yagna 0.10 and up, GitHub issue: yapapi#843")
 async def test_run_ssh(
     log_dir: Path,
     project_dir: Path,


### PR DESCRIPTION
Issue to re-enable is here: https://github.com/golemfactory/yapapi/issues/843