### PR TITLE
Event-related cleanup of `yapapi.log.SummaryLogger`

### DIFF
--- a/yapapi/events.py
+++ b/yapapi/events.py
@@ -154,14 +154,6 @@ class JobEvent(Event, abc.ABC):
     def job_id(self) -> str:
         return self.job.id
 
-    @property
-    def expires(self) -> datetime:
-        return self.job.expiration_time
-
-    @property
-    def num_offers(self) -> int:
-        return self.job.offers_collected
-
 
 @attr.s(auto_attribs=True, repr=False)
 class SubscriptionEvent(JobEvent, abc.ABC):

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -300,9 +300,6 @@ class SummaryLogger:
     # Set of agreements confirmed by providers, indexed by job id
     confirmed_agreements: Dict[JobId, Set[AgreementId]]
 
-    # Maps task id to task data
-    task_data: Dict[TaskId, Any]
-
     # Maps a job id and provider info to the list of task ids computed
     # by the provider for the given job
     provider_tasks: Dict[JobId, Dict[ProviderInfo, List[TaskId]]]
@@ -342,7 +339,6 @@ class SummaryLogger:
         self.confirmed_proposals = set()
         self.agreement_provider_info = {}
         self.confirmed_agreements = defaultdict(set)
-        self.task_data = {}
         self.script_cmds = {}
         self.provider_cost = {}
         self.provider_tasks = defaultdict(lambda: defaultdict(list))
@@ -496,7 +492,6 @@ class SummaryLogger:
 
         elif isinstance(event, events.TaskStarted):
             provider_info = self.agreement_provider_info[event.agr_id]
-            self.task_data[event.task_id] = event.task_data
             self.logger.info(
                 "Task started on provider '%s', task data: %s",
                 provider_info.name,
@@ -506,15 +501,13 @@ class SummaryLogger:
 
         elif isinstance(event, events.TaskFinished):
             provider_info = self.agreement_provider_info[event.agr_id]
-            data = self.task_data[event.task_id]
             self.logger.info(
                 "Task finished by provider '%s', task data: %s",
                 provider_info.name,
-                str_capped(data, 200),
+                str_capped(event.task_data, 200),
                 job_id=event.job_id,
             )
-            if event.task_id:
-                self.provider_tasks[event.job_id][provider_info].append(event.task_id)
+            self.provider_tasks[event.job_id][provider_info].append(event.task_id)
 
         elif isinstance(event, events.ScriptSent):
             provider_info = self.agreement_provider_info[event.agr_id]

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -46,13 +46,12 @@ from collections import defaultdict, Counter
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-import itertools
 import inspect
 import logging
 import os
 import sys
 import time
-from typing import Any, Callable, Dict, Iterator, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 if sys.version_info >= (3, 8):
     from typing import Final
@@ -279,9 +278,6 @@ class SummaryLogger:
 
     logger = get_logger("yapapi.summary")
 
-    # Generates subsequent numbers, for use in generated provider names
-    numbers: Iterator[int]
-
     # Start time of the computation, indexed by job id
     start_time: Dict[JobId, float]
 
@@ -326,7 +322,6 @@ class SummaryLogger:
         """Create a SummaryLogger."""
 
         self._wrapped_emitter = wrapped_emitter
-        self.numbers: Iterator[int] = itertools.count(1)
         self._reset_counters()
         self._print_confirmed_providers()
 

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -420,7 +420,7 @@ class SummaryLogger:
             if self.provider_cost:
                 # This means another computation run in the current Executor instance.
                 self._print_total_cost(partial=True)
-            timeout = event.expires - datetime.now(timezone.utc)
+            timeout = event.job.expiration_time - datetime.now(timezone.utc)
             # Compute the timeout as it will be seen by providers, assuming they will see
             # the Demand 5 seconds from now
             provider_timeout = timeout - timedelta(seconds=5)
@@ -443,14 +443,15 @@ class SummaryLogger:
 
         elif isinstance(event, events.NoProposalsConfirmed):
             self.time_waiting_for_proposals += event.timeout
-            if event.num_offers == 0:
+            offers_collected = event.job.offers_collected
+            if offers_collected == 0:
                 msg = (
                     "No offers have been collected from the market for"
                     f" {self.time_waiting_for_proposals.seconds}s."
                 )
             else:
                 msg = (
-                    f"{event.num_offers} {'offer has' if event.num_offers == 1 else 'offers have'} "
+                    f"{offers_collected} {'offer has' if offers_collected == 1 else 'offers have'} "
                     f"been collected from the market, but no provider has responded for "
                     f"{self.time_waiting_for_proposals.seconds}s."
                 )


### PR DESCRIPTION
Resolves #796.
Again, commits are quite independent.

NOTE: some more improvements are possible. Ideally, we would have no properties like "job_id" on "agr_id" on events. But `yapapi.log` is really messy, and I don't think it's worth the effort now - I've written down few ideas in #848, maybe we'll do this one day.