### PR TITLE
Non-async add_event_consumer

### DIFF
--- a/tests/test_add_event_consumer.py
+++ b/tests/test_add_event_consumer.py
@@ -31,9 +31,9 @@ async def test_emit_event(dummy_yagna_engine):
         got_events_3.append(event)
 
     golem = Golem(budget=1, event_consumer=event_consumer_1, app_key="NOT_A_REAL_APPKEY")
-    await golem.add_event_consumer(event_consumer_2)
+    golem.add_event_consumer(event_consumer_2)
     async with golem:
-        await golem.add_event_consumer(event_consumer_3)
+        golem.add_event_consumer(event_consumer_3)
         for sample_event in sample_events:
             event_class, event_kwargs = type(sample_event), asdict(sample_event)
             del event_kwargs["timestamp"]  # timestamp is set only internally

--- a/tests/test_add_event_consumer.py
+++ b/tests/test_add_event_consumer.py
@@ -44,9 +44,8 @@ async def test_emit_event(dummy_yagna_engine):
     assert got_events_3 == emitted_events
     assert got_events_4 == sample_events
 
-    #   NOTE: We call `Golem.add_event_consumer` and event_consumers are passed to the _Engine.
-    #         When exiting from golem contextmanager, new `_Engine` is created -> we must ensure
-    #         event consumers are not lost when `_Engine` exits -> so we repeat the same test again
+    #   When exiting from golem contextmanager, new `_Engine` is created -> we must ensure
+    #   event consumers are not lost when `_Engine` exits -> so we repeat the same test again
     got_events_1.clear()
     got_events_2.clear()
     got_events_3.clear()

--- a/yapapi/async_event_emitter.py
+++ b/yapapi/async_event_emitter.py
@@ -1,0 +1,14 @@
+from yapapi import events
+from typing import Callable
+
+
+class AsyncEventEmitter:
+    def __init__(self):
+        self._consumers = []
+
+    def add_event_consumer(self, event_consumer: Callable[[events.Event], None]):
+        self._consumers.append(event_consumer)
+
+    def emit(self, event: events.Event) -> None:
+        for consumer in self._consumers:
+            consumer(event)

--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -108,7 +108,7 @@ class _Engine:
         :param strategy: market strategy used to select providers from the market
             (e.g. LeastExpensiveLinearPayuMS or DummyMS)
         :param event_consumer: callable that will be directly executed on every Event this Engine creates.
-            NOTE: it is expected to be fast - if not, it will block the _Engine.
+            NOTE: it is expected to be fast or async - if not, it will block the _Engine.
         :param subnet_tag: use only providers in the subnet with the subnet_tag name.
             Uses `YAGNA_SUBNET` environment variable, defaults to `None`
         :param payment_driver: name of the payment driver to use. Uses `YAGNA_PAYMENT_DRIVER`

--- a/yapapi/event_dispatcher.py
+++ b/yapapi/event_dispatcher.py
@@ -9,9 +9,14 @@ class AsyncEventDispatcher:
     def __init__(self):
         self._consumers: List[AsyncWrapper] = []
 
-    def add_event_consumer(self, event_consumer: Callable[[events.Event], None]):
+    def add_event_consumer(
+        self,
+        event_consumer: Callable[[events.Event], None],
+        start_consumer: bool,
+    ):
         consumer = AsyncWrapper(event_consumer)
-        consumer.start()
+        if start_consumer:
+            consumer.start()
         self._consumers.append(consumer)
 
     def emit(self, event: events.Event):

--- a/yapapi/event_dispatcher.py
+++ b/yapapi/event_dispatcher.py
@@ -5,7 +5,7 @@ from yapapi import events
 from yapapi.utils import AsyncWrapper
 
 
-class AsyncEventEmitter:
+class AsyncEventDispatcher:
     def __init__(self):
         self._consumers: List[AsyncWrapper] = []
 

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -141,7 +141,7 @@ class Golem:
 
     def add_event_consumer(self, event_consumer: Callable[[events.Event], None]) -> None:
         """Initialize another `event_consumer`, working just like `event_consumer` passed in `__init__`"""
-        self._event_dispatcher.add_event_consumer(event_consumer)
+        self._event_dispatcher.add_event_consumer(event_consumer, self.operative)
 
     @property
     def driver(self) -> str:
@@ -197,7 +197,8 @@ class Golem:
     @property
     def operative(self) -> bool:
         """Return True if Golem started and didn't stop"""
-        return self._engine.started
+        engine_init_finished = hasattr(self, "_engine")  # to avoid special cases in __init__
+        return engine_init_finished and self._engine.started
 
     async def start(self) -> None:
         """Start the Golem engine in non-contextmanager mode.
@@ -226,10 +227,7 @@ class Golem:
                     #   Something started us before we got to the locked part
                     return
 
-                #   NOTE: this is necessary only if Golem was stopped before, because stopping Golem
-                #         closes event consumers, and here we reopen them
                 self._event_dispatcher.start()
-
                 await self._engine.start()
         except:
             await self._stop_with_exc_info(*sys.exc_info())

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -21,6 +21,7 @@ from typing_extensions import AsyncGenerator
 
 import yapapi
 from yapapi import events
+from yapapi.async_event_emitter import AsyncEventEmitter
 from yapapi.ctx import WorkContext
 from yapapi.engine import _Engine
 from yapapi.executor import Executor
@@ -117,7 +118,9 @@ class Golem:
             warn_deprecated("network", "payment_network", "0.7.0", Deprecated.parameter)
             payment_network = payment_network if payment_network else network
 
-        self._event_consumers = [event_consumer or self._default_event_consumer()]
+        self._async_event_emitter = AsyncEventEmitter()
+
+        self.add_event_consumer(event_consumer or self._default_event_consumer())
 
         if not strategy:
             strategy = self._initialize_default_strategy()
@@ -125,6 +128,7 @@ class Golem:
         self._engine_args = {
             "budget": budget,
             "strategy": strategy,
+            "event_consumer": self._async_event_emitter.emit,
             "subnet_tag": subnet_tag,
             "payment_driver": payment_driver,
             "payment_network": payment_network,
@@ -135,12 +139,9 @@ class Golem:
         self._engine: _Engine = self._get_new_engine()
         self._engine_state_lock = asyncio.Lock()
 
-    async def add_event_consumer(self, event_consumer: Callable[[events.Event], None]) -> None:
+    def add_event_consumer(self, event_consumer: Callable[[events.Event], None]) -> None:
         """Initialize another `event_consumer`, working just like `event_consumer` passed in `__init__`"""
-        if self._engine.started:
-            await self._engine.add_event_consumer(event_consumer)
-
-        self._event_consumers.append(event_consumer)
+        self._async_event_emitter.add_event_consumer(event_consumer)
 
     @property
     def driver(self) -> str:
@@ -224,11 +225,6 @@ class Golem:
                 if self.operative:
                     #   Something started us before we got to the locked part
                     return
-
-                #   NOTE: we add consumers to the not-yet-started Engine, because this is the only
-                #   way to capture ShutdownFinished event with current Engine implementation
-                for event_consumer in self._event_consumers:
-                    await self._engine.add_event_consumer(event_consumer)
                 await self._engine.start()
         except:
             await self._stop_with_exc_info(*sys.exc_info())
@@ -481,5 +477,5 @@ class Golem:
             max_price_for={com.Counter.CPU: Decimal("0.2"), com.Counter.TIME: Decimal("0.1")},
         )
         strategy = DecreaseScoreForUnconfirmedAgreement(base_strategy, 0.5)
-        self._event_consumers.append(strategy.on_event)
+        self.add_event_consumer(strategy.on_event)
         return strategy


### PR DESCRIPTION
Resolves #851 

All logic related to multiple event consumers was removed from the `_Engine` class, and minimized in `Golem`.
This design is cleaner imo, as we have now a separate class with a clearly defined responsibility.

Reading commits separately might make sense (except for the `AsyncEventEmitter` class).