### PR TITLE
Fix mid-agreement payments integration test (to b0.9)

### DIFF
--- a/tests/goth_tests/test_mid_agreement_payments/test_mid_agreement_payments.py
+++ b/tests/goth_tests/test_mid_agreement_payments/test_mid_agreement_payments.py
@@ -22,6 +22,7 @@ async def check_debit_note_freq(events):
     freq = None
     expected_note_num = 1
     total_time = 0
+    note_num = None
     async for line in events:
         if freq is None:
             m = re.search(r"Debit notes interval: ([0-9]+)", line)


### PR DESCRIPTION
Without this change the integration test would fail saying that note_num was not declared instead of saying "Expected at least two debit notes".

The problem affects only failed tests — it fixes incorrect error message when the test fails because there are not debit notes from the provider.