### PR TITLE
Failed to spawn instance fix (assign to agreement variable before creating activity)

### DIFF
--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -634,7 +634,10 @@ class _Engine:
         )
 
     async def start_worker(
-        self, job: "Job", run_worker: Callable[[WorkContext], Awaitable]
+        self,
+        job: "Job",
+        run_worker: Callable[[WorkContext], Awaitable],
+        on_agreement_ready: Callable[[Agreement], None] = None,
     ) -> Optional[asyncio.Task]:
         loop = asyncio.get_event_loop()
 
@@ -644,6 +647,8 @@ class _Engine:
             It creates an Activity for a given Agreement, then creates a WorkContext for this Activity
             and then executes `run_worker` with this WorkContext.
             """
+            if on_agreement_ready:
+                on_agreement_ready(agreement)
             self._all_agreements[agreement.id] = agreement
 
             job.emit(events.WorkerStarted, agreement=agreement)

--- a/yapapi/services/service_runner.py
+++ b/yapapi/services/service_runner.py
@@ -360,6 +360,7 @@ class ServiceRunner(AsyncContextManager):
                 await self._job.agreements_pool.release_agreement(agreement.id, allow_reuse=False)
 
         def on_agreement_ready(agreement_ready: Agreement) -> None:
+            nonlocal agreement
             agreement = agreement_ready
 
         while not self._stopped:

--- a/yapapi/services/service_runner.py
+++ b/yapapi/services/service_runner.py
@@ -328,7 +328,8 @@ class ServiceRunner(AsyncContextManager):
         instance = service.service_instance
 
         async def _worker(work_context: WorkContext) -> None:
-            nonlocal agreement, instance
+            nonlocal instance
+            assert agreement is not None
 
             activity = work_context._activity
 

--- a/yapapi/services/service_runner.py
+++ b/yapapi/services/service_runner.py
@@ -359,10 +359,13 @@ class ServiceRunner(AsyncContextManager):
                 await self._job.engine.accept_payments_for_agreement(self._job.id, agreement.id)
                 await self._job.agreements_pool.release_agreement(agreement.id, allow_reuse=False)
 
+        def on_agreement_ready(agreement_ready: Agreement) -> None:
+            agreement = agreement_ready
+
         while not self._stopped:
             agreement = None
             await asyncio.sleep(1.0)
-            task = await self._job.engine.start_worker(self._job, _worker)
+            task = await self._job.engine.start_worker(self._job, _worker, on_agreement_ready)
             if not task:
                 continue
             try:

--- a/yapapi/services/service_runner.py
+++ b/yapapi/services/service_runner.py
@@ -330,7 +330,6 @@ class ServiceRunner(AsyncContextManager):
         async def _worker(work_context: WorkContext) -> None:
             nonlocal agreement, instance
 
-            agreement = work_context._agreement
             activity = work_context._activity
 
             work_context.emit(events.ServiceStarted, service=service)


### PR DESCRIPTION
Fixes problem described in https://github.com/golemfactory/yapapi/issues/922#issuecomment-1089945812:
> 1. `agreement` is set in `_worker` function.
> 2. but `_worker` is called after `await self.create_activity(agreement.id)` in `worker_task` in `start_worker`.
> 3. so if an error happens in `create_activity` (#922, #924), `agreement` won't be set and `Failed to spawn instance` (a.k.a. `This shouldn't happen`) will be logged.