### PR TITLE
fixes 927 so ProviderFilter handles coroutine callback

### DIFF
--- a/yapapi/contrib/strategy/provider_filter.py
+++ b/yapapi/contrib/strategy/provider_filter.py
@@ -72,7 +72,7 @@ class ProviderFilter(WrappingMarketStrategy):
 
     async def score_offer(self, offer: OfferProposal) -> float:
         if inspect.iscoroutinefunction(self._is_allowed):
-            allowed = await self._is_allowed(offer.issuer)
+            allowed = await self._is_allowed(offer.issuer) # type: ignore
         else:
             allowed = self._is_allowed(offer.issuer)
 

--- a/yapapi/contrib/strategy/provider_filter.py
+++ b/yapapi/contrib/strategy/provider_filter.py
@@ -72,7 +72,7 @@ class ProviderFilter(WrappingMarketStrategy):
 
     async def score_offer(self, offer: OfferProposal) -> float:
         if inspect.iscoroutinefunction(self._is_allowed):
-            allowed = await self._is_allowed(offer.issuer) # type: ignore
+            allowed = await self._is_allowed(offer.issuer)  # type: ignore
         else:
             allowed = self._is_allowed(offer.issuer)
 

--- a/yapapi/contrib/strategy/provider_filter.py
+++ b/yapapi/contrib/strategy/provider_filter.py
@@ -72,7 +72,7 @@ class ProviderFilter(WrappingMarketStrategy):
 
     async def score_offer(self, offer: OfferProposal) -> float:
         if inspect.iscoroutinefunction(self._is_allowed):
-            allowed = await self._is_allowed(offer.issuer)  # type: ignore
+            allowed = await self._is_allowed(offer.issuer)
         else:
             allowed = self._is_allowed(offer.issuer)
 

--- a/yapapi/contrib/strategy/provider_filter.py
+++ b/yapapi/contrib/strategy/provider_filter.py
@@ -71,9 +71,10 @@ class ProviderFilter(WrappingMarketStrategy):
         self._is_allowed = is_allowed
 
     async def score_offer(self, offer: OfferProposal) -> float:
-        allowed = self._is_allowed(offer.issuer)
-        if inspect.iscoroutinefunction(allowed):
-            allowed = await allowed  # type: ignore
+        if inspect.iscoroutinefunction(self._is_allowed):
+            allowed = await self._is_allowed(offer.issuer)  # type: ignore
+        else:
+            allowed = self._is_allowed(offer.issuer)
 
         if not allowed:
             return SCORE_REJECTED


### PR DESCRIPTION
Hello, I am suggesting a patch so that ProviderFilter in yapapi/contrib/strategy/provider_filter.py works as intended when passed a coroutine callback. This should resolve https://github.com/golemfactory/yapapi/issues/927
Thank you for considering my suggestion.

This is a new pull request to b0.9 instead of to master but does not differ from the original pull request for master. I hope this simplifies merging! this replaces (closed) pull request #928, which @johny-b commented on as a good candidate to merge with b0.9