### PR TITLE
Accepted amount for a debit note/invoice is decided in the MarketStrategy

### DIFF
--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -101,7 +101,8 @@ Market strategies
 ==========================
 
 .. autoclass:: yapapi.strategy.MarketStrategy
-    :members: decorate_demand, score_offer, respond_to_provider_offer, acceptable_prop_value_range_overrides, acceptable_prop_value_ranges
+    :members: decorate_demand, score_offer, respond_to_provider_offer, acceptable_prop_value_range_overrides, acceptable_prop_value_ranges,
+              invoice_accepted_amount, debit_note_accepted_amount
 
 .. autoclass:: yapapi.strategy.WrappingMarketStrategy
     :members: __init__, base_strategy

--- a/yapapi/invoice_manager.py
+++ b/yapapi/invoice_manager.py
@@ -1,6 +1,7 @@
 from asyncio import CancelledError
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional, Set, TYPE_CHECKING
+from decimal import Decimal
+from typing import Awaitable, Callable, Dict, Optional, Set, TYPE_CHECKING
 import sys
 
 from yapapi import events
@@ -18,6 +19,11 @@ class AgreementData:
     invoice: Optional["Invoice"] = None
     payable: bool = False
     paid: bool = False
+
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class InvoiceManager:
@@ -71,7 +77,10 @@ class InvoiceManager:
         self._agreement_data[agreement_id].payable = True
 
     async def attempt_payment(
-        self, agreement_id: str, get_allocation: Callable[["Invoice"], "Allocation"]
+        self,
+        agreement_id: str,
+        get_allocation: Callable[["Invoice"], "Allocation"],
+        get_accepted_amount: Callable[["Invoice"], Awaitable[Decimal]],
     ) -> bool:
         ad = self._agreement_data.get(agreement_id)
         if not ad or not ad.invoice or not ad.payable or ad.paid:
@@ -80,12 +89,23 @@ class InvoiceManager:
         invoice = ad.invoice
         try:
             allocation = get_allocation(invoice)
-            await invoice.accept(amount=invoice.amount, allocation=allocation)
-            ad.job.emit(
-                events.InvoiceAccepted,
-                agreement=ad.agreement,
-                invoice=invoice,
-            )
+            accepted_amount = await get_accepted_amount(invoice)
+            if accepted_amount >= Decimal(invoice.amount):
+                await invoice.accept(amount=accepted_amount, allocation=allocation)
+                ad.job.emit(
+                    events.InvoiceAccepted,
+                    agreement=ad.agreement,
+                    invoice=invoice,
+                )
+            else:
+                #   We should reject the invoice, but it's not implemented in yagna,
+                #   so we just ignore it now
+                logger.warning(
+                    "Ignored invoice %s for %s, we accept only %s",
+                    invoice.invoice_id,
+                    invoice.amount,
+                    accepted_amount,
+                )
         except CancelledError:
             raise
         except Exception:

--- a/yapapi/strategy/wrapping_strategy.py
+++ b/yapapi/strategy/wrapping_strategy.py
@@ -1,4 +1,5 @@
 import abc
+from decimal import Decimal
 
 from yapapi.props.builder import DemandBuilder
 from yapapi import rest
@@ -32,6 +33,12 @@ class WrappingMarketStrategy(BaseMarketStrategy, abc.ABC):
 
     async def score_offer(self, offer: rest.market.OfferProposal) -> float:
         return await self.base_strategy.score_offer(offer)
+
+    async def invoice_accepted_amount(self, invoice: rest.payment.Invoice) -> Decimal:
+        return await self.base_strategy.invoice_accepted_amount(invoice)
+
+    async def debit_note_accepted_amount(self, debit_note: rest.payment.DebitNote) -> Decimal:
+        return await self.base_strategy.debit_note_accepted_amount(debit_note)
 
     async def respond_to_provider_offer(
         self,


### PR DESCRIPTION
This is necessary for the "reputation" requestor agent.

Also: I think this is sort-of-necessary for any "serious" mainnet deployment, as we need a way to refuse unfairly-super-high debit notes/invoices (--> dapps?).

Imho this deserves a `goth` test, but I'd rather not do this now --> I've created an issue #963 

(These changes were already reviewed once, in the first weeks of the "reputation" project, but there were some minor changes since then).
