### PR TITLE
Blue/activity start time

### DIFF
--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -653,6 +653,8 @@ class _Engine:
 
             job.emit(events.WorkerStarted, agreement=agreement)
 
+            activity_start_time = datetime.now()
+
             try:
                 activity = await self.create_activity(agreement.id)
             except Exception:
@@ -662,7 +664,7 @@ class _Engine:
             work_context = WorkContext(activity, agreement, self.storage_manager, emitter=job.emit)
             work_context.emit(events.ActivityCreated)
 
-            self._activity_created_at[activity.id] = datetime.now()
+            self._activity_created_at[activity.id] = activity_start_time
 
             async with activity:
                 self.accept_debit_notes_for_agreement(job.id, agreement.id)

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -456,7 +456,10 @@ class SummaryLogger:
         elif isinstance(event, events.AgreementCreated):
             provider_name = event.provider_info.name or event.provider_id
             self.logger.info(
-                "Agreement proposed to provider '%s' (%s)", provider_name, event.provider_id, job_id=event.job_id
+                "Agreement proposed to provider '%s' (%s)",
+                provider_name,
+                event.provider_id,
+                job_id=event.job_id,
             )
             self.agreement_provider_info[event.agr_id] = ProviderInfo(
                 event.provider_id, provider_name, event.provider_info.subnet_tag

--- a/yapapi/log.py
+++ b/yapapi/log.py
@@ -456,7 +456,7 @@ class SummaryLogger:
         elif isinstance(event, events.AgreementCreated):
             provider_name = event.provider_info.name or event.provider_id
             self.logger.info(
-                "Agreement proposed to provider '%s'", provider_name, job_id=event.job_id
+                "Agreement proposed to provider '%s' (%s)", provider_name, event.provider_id, job_id=event.job_id
             )
             self.agreement_provider_info[event.agr_id] = ProviderInfo(
                 event.provider_id, provider_name, event.provider_info.subnet_tag


### PR DESCRIPTION
closes #948 

while trying to reproduce the issue, I figured it's not caused by the final note but by a longer delay when lauching a worker for the given activity (most likely caused by the time it takes the provider to pull the image etc)