### PR TITLE
#986: Move restart required logic to Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 *.log
 *.png
 .coverage
+.requirements.txt
 
 tests/goth_tests/assets/
 

--- a/examples/custom-usage-counter/custom_usage_counter.py
+++ b/examples/custom-usage-counter/custom_usage_counter.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import asyncio
-import pathlib
-import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
+import pathlib
+import sys
 
 from yapapi import Golem
 from yapapi.ctx import ActivityUsage

--- a/examples/custom-usage-counter/custom_usage_counter.py
+++ b/examples/custom-usage-counter/custom_usage_counter.py
@@ -1,24 +1,19 @@
 #!/usr/bin/env python3
-import argparse
 import asyncio
-
+import pathlib
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
-import pathlib
-import sys
-
-from yapapi.strategy import LeastExpensiveLinearPayuMS, DecreaseScoreForUnconfirmedAgreement
-
-from yapapi.log import enable_default_logger
-
-from yapapi.props.base import prop, constraint
-from yapapi.props import inf, com
 
 from yapapi import Golem
 from yapapi.ctx import ActivityUsage
+from yapapi.log import enable_default_logger
 from yapapi.payload import Payload
+from yapapi.props import com, inf
+from yapapi.props.base import constraint
 from yapapi.services import Service, ServiceState
+from yapapi.strategy import LeastExpensiveLinearPayuMS
 
 examples_dir = pathlib.Path(__file__).resolve().parent.parent
 sys.path.append(str(examples_dir))
@@ -56,10 +51,6 @@ class CustomCounterService(Service):
         async for s in super().shutdown():
             yield s
         print(f"service {self.id} stopped on '{self.provider_name}'")
-
-    async def reset(self):
-        # We don't have to do anything when the service is restarted
-        pass
 
 
 async def main(running_time_sec, subnet_tag, driver=None, network=None):

--- a/examples/http-proxy/http_proxy.py
+++ b/examples/http-proxy/http_proxy.py
@@ -3,10 +3,10 @@
 a simple http proxy example
 """
 import asyncio
+from datetime import datetime, timedelta, timezone
 import pathlib
 import shlex
 import sys
-from datetime import datetime, timedelta, timezone
 
 from yapapi import Golem
 from yapapi.contrib.service.http_proxy import HttpProxyService, LocalHttpProxy

--- a/examples/http-proxy/http_proxy.py
+++ b/examples/http-proxy/http_proxy.py
@@ -3,29 +3,25 @@
 a simple http proxy example
 """
 import asyncio
-
-from datetime import datetime, timedelta, timezone
 import pathlib
 import shlex
 import sys
-
+from datetime import datetime, timedelta, timezone
 
 from yapapi import Golem
-from yapapi.services import ServiceState
-from yapapi.payload import vm
-
 from yapapi.contrib.service.http_proxy import HttpProxyService, LocalHttpProxy
-
+from yapapi.payload import vm
+from yapapi.services import ServiceState
 
 examples_dir = pathlib.Path(__file__).resolve().parent.parent
 sys.path.append(str(examples_dir))
 
 from utils import (
-    build_parser,
     TEXT_COLOR_CYAN,
     TEXT_COLOR_DEFAULT,
-    run_golem_example,
+    build_parser,
     print_env_info,
+    run_golem_example,
 )
 
 # the timeout after we commission our service instances
@@ -79,10 +75,6 @@ class HttpService(HttpProxyService):
 
     # we don't need to implement `run` since, after the service is started,
     # all communication is performed through the VPN
-
-    async def reset(self):
-        # We don't have to do anything when the service is restarted
-        pass
 
 
 # ######## Main application code which spawns the Golem service and the local HTTP server

--- a/examples/simple-service-poc/simple_service.py
+++ b/examples/simple-service-poc/simple_service.py
@@ -3,11 +3,11 @@
 the requestor agent controlling and interacting with the "simple service"
 """
 import asyncio
+from datetime import datetime, timedelta, timezone
 import pathlib
 import random
 import string
 import sys
-from datetime import datetime, timedelta, timezone
 
 from yapapi import Golem
 from yapapi.payload import vm

--- a/examples/simple-service-poc/simple_service.py
+++ b/examples/simple-service-poc/simple_service.py
@@ -3,28 +3,26 @@
 the requestor agent controlling and interacting with the "simple service"
 """
 import asyncio
-from datetime import datetime, timedelta, timezone
 import pathlib
 import random
 import string
 import sys
-
+from datetime import datetime, timedelta, timezone
 
 from yapapi import Golem
-from yapapi.services import Service, ServiceState
-
 from yapapi.payload import vm
+from yapapi.services import Service, ServiceState
 
 examples_dir = pathlib.Path(__file__).resolve().parent.parent
 sys.path.append(str(examples_dir))
 
 from utils import (
-    build_parser,
     TEXT_COLOR_CYAN,
     TEXT_COLOR_DEFAULT,
+    TEXT_COLOR_MAGENTA,
     TEXT_COLOR_RED,
     TEXT_COLOR_YELLOW,
-    TEXT_COLOR_MAGENTA,
+    build_parser,
     format_usage,
     print_env_info,
     run_golem_example,
@@ -112,10 +110,6 @@ class SimpleService(Service):
         if self._show_usage:
             cost = await self._ctx.get_cost()
             print(f"{TEXT_COLOR_MAGENTA} --- {self.name}  COST: {cost} {TEXT_COLOR_DEFAULT}")
-
-    async def reset(self):
-        # We don't have to do anything when the service is restarted
-        pass
 
 
 async def main(

--- a/examples/ssh/ssh.py
+++ b/examples/ssh/ssh.py
@@ -1,20 +1,15 @@
 #!/usr/bin/env python3
 import asyncio
-from datetime import timedelta
 import pathlib
 import random
-import sys
 import string
+import sys
+from datetime import datetime, timedelta
 from uuid import uuid4
 
-
-from datetime import datetime
-
-from yapapi import (
-    Golem,
-    __version__ as yapapi_version,
-)
-from yapapi.log import enable_default_logger, log_summary, log_event_repr  # noqa
+from yapapi import Golem
+from yapapi import __version__ as yapapi_version
+from yapapi.log import enable_default_logger, log_event_repr, log_summary  # noqa
 from yapapi.payload import vm
 from yapapi.services import Service
 
@@ -22,13 +17,13 @@ examples_dir = pathlib.Path(__file__).resolve().parent.parent
 sys.path.append(str(examples_dir))
 
 from utils import (
-    build_parser,
     TEXT_COLOR_CYAN,
     TEXT_COLOR_DEFAULT,
     TEXT_COLOR_RED,
     TEXT_COLOR_YELLOW,
-    run_golem_example,
+    build_parser,
     print_env_info,
+    run_golem_example,
 )
 
 
@@ -70,10 +65,6 @@ class SshService(Service):
         )
 
         print(f"{TEXT_COLOR_RED}password: {password}{TEXT_COLOR_DEFAULT}")
-
-    async def reset(self):
-        # We don't have to do anything when the service is restarted
-        pass
 
 
 async def main(subnet_tag, payment_driver=None, payment_network=None, num_instances=2):

--- a/examples/ssh/ssh.py
+++ b/examples/ssh/ssh.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 import asyncio
+from datetime import datetime, timedelta
 import pathlib
 import random
 import string
 import sys
-from datetime import datetime, timedelta
 from uuid import uuid4
 
 from yapapi import Golem

--- a/examples/webapp/webapp.py
+++ b/examples/webapp/webapp.py
@@ -1,27 +1,23 @@
 #!/usr/bin/env python3
 import asyncio
-from datetime import timedelta
 import pathlib
 import sys
-
-
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from yapapi import Golem
+from yapapi.contrib.service.http_proxy import HttpProxyService, LocalHttpProxy
 from yapapi.payload import vm
 from yapapi.services import Service, ServiceState
-
-from yapapi.contrib.service.http_proxy import HttpProxyService, LocalHttpProxy
 
 examples_dir = pathlib.Path(__file__).resolve().parent.parent
 sys.path.append(str(examples_dir))
 
 from utils import (
-    build_parser,
     TEXT_COLOR_CYAN,
     TEXT_COLOR_DEFAULT,
-    run_golem_example,
+    build_parser,
     print_env_info,
+    run_golem_example,
 )
 
 HTTP_IMAGE_HASH = "c37c1364f637c199fe710ca62241ff486db92c875b786814c6030aa1"
@@ -63,10 +59,6 @@ class HttpService(HttpProxyService):
         )
         yield script
 
-    async def reset(self):
-        # We don't have to do anything when the service is restarted
-        pass
-
 
 class DbService(Service):
     @staticmethod
@@ -85,10 +77,6 @@ class DbService(Service):
         script = self._ctx.new_script(timeout=timedelta(seconds=30))
         script.run("/bin/run_rqlite.sh")
         yield script
-
-    async def reset(self):
-        # We don't have to do anything when the service is restarted
-        pass
 
 
 async def main(subnet_tag, payment_driver, payment_network, port):

--- a/examples/webapp/webapp.py
+++ b/examples/webapp/webapp.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import asyncio
+from datetime import datetime, timedelta
 import pathlib
 import sys
-from datetime import datetime, timedelta
 
 from yapapi import Golem
 from yapapi.contrib.service.http_proxy import HttpProxyService, LocalHttpProxy

--- a/examples/webapp_fileupload/webapp_fileupload.py
+++ b/examples/webapp_fileupload/webapp_fileupload.py
@@ -1,27 +1,23 @@
 #!/usr/bin/env python3
 import asyncio
-from datetime import timedelta
 import pathlib
 import sys
-
-
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from yapapi import Golem
+from yapapi.contrib.service.http_proxy import HttpProxyService, LocalHttpProxy
 from yapapi.payload import vm
 from yapapi.services import Service, ServiceState
-
-from yapapi.contrib.service.http_proxy import HttpProxyService, LocalHttpProxy
 
 examples_dir = pathlib.Path(__file__).resolve().parent.parent
 sys.path.append(str(examples_dir))
 
 from utils import (
-    build_parser,
     TEXT_COLOR_CYAN,
     TEXT_COLOR_DEFAULT,
-    run_golem_example,
+    build_parser,
     print_env_info,
+    run_golem_example,
 )
 
 HTTP_IMAGE_HASH = "c37c1364f637c199fe710ca62241ff486db92c875b786814c6030aa1"
@@ -72,10 +68,6 @@ class HttpService(HttpProxyService):
             script.download_file("/logs/err", "webapp_err.txt")
             yield script
 
-    async def reset(self):
-        # We don't have to do anything when the service is restarted
-        pass
-
 
 class DbService(Service):
     @staticmethod
@@ -94,10 +86,6 @@ class DbService(Service):
         script = self._ctx.new_script(timeout=timedelta(seconds=30))
         script.run("/bin/run_rqlite.sh")
         yield script
-
-    async def reset(self):
-        # We don't have to do anything when the service is restarted
-        pass
 
 
 async def main(subnet_tag, payment_driver, payment_network, port):

--- a/examples/webapp_fileupload/webapp_fileupload.py
+++ b/examples/webapp_fileupload/webapp_fileupload.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import asyncio
+from datetime import datetime, timedelta
 import pathlib
 import sys
-from datetime import datetime, timedelta
 
 from yapapi import Golem
 from yapapi.contrib.service.http_proxy import HttpProxyService, LocalHttpProxy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,12 @@ poethepoet = "^0.8.0"
 pytest-cov = "^2.11"
 factory-boy = "^3.2.0"
 
+[tool.isort]
+profile = "black"
+force_sort_within_sections = true
+sections=["FUTURE","THIRDPARTY","FIRSTPARTY","LOCALFOLDER"]
+default_section="THIRDPARTY"  # STDLIB section will be cobined with THIRDPARTY section
+
 [tool.black]
 line-length = 100
 target-version = ['py36']

--- a/tests/services/test_cluster.py
+++ b/tests/services/test_cluster.py
@@ -1,11 +1,13 @@
 import asyncio
 import itertools
 import sys
-import pytest
-from yapapi.services import Service, ServiceRunner
-from unittest.mock import Mock, patch
 from unittest import mock
+from unittest.mock import Mock, patch
+
+import pytest
+
 from yapapi import Golem
+from yapapi.services import Service, ServiceRunner
 
 
 class _TestService(Service):
@@ -102,7 +104,7 @@ async def test_spawn_instances(kwargs, args, error, monkeypatch):
 
     assert len(spawn_instance.mock_calls) == len(args)
     for call_args, args in zip(spawn_instance.call_args_list, args):
-        service, network, network_address, restart_condition = call_args[0]
+        service, network, network_address = call_args[0]
         assert service.init_kwargs == args[0]
         assert network_address == args[1]
 

--- a/tests/services/test_cluster.py
+++ b/tests/services/test_cluster.py
@@ -1,10 +1,9 @@
 import asyncio
 import itertools
+import pytest
 import sys
 from unittest import mock
 from unittest.mock import Mock, patch
-
-import pytest
 
 from yapapi import Golem
 from yapapi.services import Service, ServiceRunner

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -1,8 +1,8 @@
 import asyncio
-import json
-import sys
 from datetime import datetime, timedelta
 from decimal import Decimal
+import json
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -17,7 +17,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
 from typing_extensions import AsyncGenerator
 
 if sys.version_info > (3, 8):

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -1,9 +1,10 @@
 import asyncio
+import json
 import sys
 from datetime import datetime, timedelta
-import json
 from decimal import Decimal
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Awaitable,
@@ -15,8 +16,8 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    TYPE_CHECKING,
 )
+
 from typing_extensions import AsyncGenerator
 
 if sys.version_info > (3, 8):
@@ -24,12 +25,11 @@ if sys.version_info > (3, 8):
 else:
     from typing_extensions import TypedDict
 
-
 import yapapi
 from yapapi import events
-from yapapi.event_dispatcher import AsyncEventDispatcher
 from yapapi.ctx import WorkContext
 from yapapi.engine import _Engine
+from yapapi.event_dispatcher import AsyncEventDispatcher
 from yapapi.executor import Executor
 from yapapi.executor.task import Task
 from yapapi.network import Network
@@ -37,8 +37,10 @@ from yapapi.payload import Payload
 from yapapi.props import com
 from yapapi.script import Script
 from yapapi.services import Cluster, ServiceType
-from yapapi.strategy import DecreaseScoreForUnconfirmedAgreement, LeastExpensiveLinearPayuMS
-
+from yapapi.strategy import (
+    DecreaseScoreForUnconfirmedAgreement,
+    LeastExpensiveLinearPayuMS,
+)
 
 if TYPE_CHECKING:
     from yapapi.strategy import BaseMarketStrategy
@@ -361,7 +363,6 @@ class Golem:
         instance_params: Optional[Iterable[Dict]] = None,
         payload: Optional[Payload] = None,
         expiration: Optional[datetime] = None,
-        respawn_unstarted_instances=True,
         network: Optional[Network] = None,
         network_addresses: Optional[List[str]] = None,
     ) -> Cluster[ServiceType]:
@@ -384,8 +385,6 @@ class Golem:
         :param payload: optional runtime definition for the service; if not provided, the
             payload specified by the :func:`~yapapi.services.Service.get_payload()` method of `service_class` is used
         :param expiration: optional expiration datetime for the service
-        :param respawn_unstarted_instances: if an instance fails in the `starting` state, should
-            the returned :class:`~yapapi.services.Cluster` try to spawn another instance
         :param network: optional :class:`~yapapi.network.Network`, representing a VPN to attach this
             :class:`~yapapi.services.Cluster`'s instances to
         :param network_addresses: optional list of addresses to assign to consecutive spawned instances.
@@ -463,7 +462,6 @@ class Golem:
             service_class=service_class,
             payload=payload,
             expiration=expiration,
-            respawn_unstarted_instances=respawn_unstarted_instances,
             network=network,
         )
 

--- a/yapapi/services/cluster.py
+++ b/yapapi/services/cluster.py
@@ -1,7 +1,7 @@
 """Implementation of high-level services API."""
+from datetime import datetime, timedelta, timezone
 import itertools
 import sys
-from datetime import datetime, timedelta, timezone
 from typing import (
     AsyncContextManager,
     Dict,

--- a/yapapi/services/cluster.py
+++ b/yapapi/services/cluster.py
@@ -39,7 +39,6 @@ class Cluster(AsyncContextManager, Generic[ServiceType]):
         service_class: Type[ServiceType],
         payload: Payload,
         expiration: Optional[datetime] = None,
-        respawn_unstarted_instances: bool = True,
         network: Optional[Network] = None,
     ):
         """Initialize this Cluster.
@@ -49,8 +48,6 @@ class Cluster(AsyncContextManager, Generic[ServiceType]):
         :param payload: definition of service runtime for this Cluster
         :param expiration: a date before which all agreements related to running services
             in this Cluster should be terminated
-        :param respawn_unstarted_instances: if an instance fails in the `starting` state,
-            should this Cluster try to spawn another instance
         :param network: optional Network representing the VPN that this Cluster's instances will
             be attached to.
         """
@@ -59,7 +56,6 @@ class Cluster(AsyncContextManager, Generic[ServiceType]):
         job = Job(engine, expiration, payload)
         self.service_runner = ServiceRunner(job)
         self._service_class = service_class
-        self._respawn_unstarted_instances = respawn_unstarted_instances
         self._network: Optional[Network] = network
 
         self._task_ids = itertools.count(1)

--- a/yapapi/services/cluster.py
+++ b/yapapi/services/cluster.py
@@ -1,7 +1,7 @@
 """Implementation of high-level services API."""
 import itertools
-from datetime import timedelta, datetime, timezone
 import sys
+from datetime import datetime, timedelta, timezone
 from typing import (
     AsyncContextManager,
     Dict,
@@ -14,15 +14,15 @@ from typing import (
 )
 
 if sys.version_info >= (3, 8):
-    from typing import Final
     from contextlib import AsyncExitStack
+    from typing import Final
 else:
     from typing_extensions import Final
     from async_exit_stack import AsyncExitStack  # type: ignore
 
+from yapapi.engine import Job, _Engine
 from yapapi.network import Network
 from yapapi.payload import Payload
-from yapapi.engine import _Engine, Job
 
 from .service import ServiceType
 from .service_runner import ServiceRunner
@@ -162,20 +162,8 @@ class Cluster(AsyncContextManager, Generic[ServiceType]):
                 network_address = network_addresses[ix]
 
             service = self.service_class(**single_instance_params)  # type: ignore
-            respawn_condition = (
-                self._instance_not_started if self._respawn_unstarted_instances else None
-            )
-            self.service_runner.add_instance(
-                service, self.network, network_address, respawn_condition
-            )
+            self.service_runner.add_instance(service, self.network, network_address)
             service._set_cluster(self)
-
-    @staticmethod
-    def _instance_not_started(service: ServiceType) -> bool:
-        return (
-            service.exc_info() != (None, None, None)
-            and not service.service_instance.started_successfully
-        )
 
     def _resolve_instance_params(
         self,

--- a/yapapi/services/service.py
+++ b/yapapi/services/service.py
@@ -218,11 +218,6 @@ class Service:
         A clean exit from a handler function triggers the engine to transition the state of the
         instance to the next stage in service's lifecycle - in this case, to `running`.
 
-        On the other hand, any unhandled exception will cause the instance to be either retried on
-        another provider node, if the :class:`Cluster`'s :attr:`respawn_unstarted_instances` argument is set to
-        `True` in :func:`~yapapi.Golem.run_service`, which is also the default behavior, or altogether terminated, if
-        :attr:`respawn_unstarted_instances` is set to `False`.
-
         **Example**::
 
 
@@ -371,7 +366,7 @@ class Service:
 
     @property
     def restart_condition(self) -> bool:
-        """Dictate condition based on which this instance will be restarted."""
+        """Dictated condition based on which this instance will be restarted."""
         return (
             self.exc_info != (None, None, None) and not self.__service_instance.started_successfully
         )

--- a/yapapi/services/service.py
+++ b/yapapi/services/service.py
@@ -23,7 +23,6 @@ from yapapi.ctx import WorkContext
 from yapapi.network import Network, Node
 from yapapi.payload import Payload
 from yapapi.script import Script
-from yapapi.utils import warn_deprecated_msg
 
 from .service_state import ServiceState
 
@@ -367,16 +366,8 @@ class Service:
         Handlers of a restarted service are called more then once - all of the cleanup necessary between calls
         should be implemented here. E.g. if we initialize a counter in :func:`Service.__init__` and increment it
         in :func:`Service.start()`, we might want to reset it here to the initial value.
-
-        Target implementation (0.10.0 and up) will raise NotImplementedError. Current implementation only warns about
-        this future change.
         """
-
-        msg = (
-            "Default implementation of Service.reset will raise NotImplementedError starting from 0.10.0. "
-            f"You should implement this method on {type(self)}"
-        )
-        warn_deprecated_msg(msg)
+        pass
 
     @property
     def restart_condition(self) -> bool:

--- a/yapapi/utils.py
+++ b/yapapi/utils.py
@@ -1,12 +1,11 @@
 """Utility functions and classes used within yapapi."""
 import asyncio
-from datetime import datetime, timezone, tzinfo
 import enum
 import functools
 import logging
-from typing import AsyncContextManager, Callable, Optional
 import warnings
-
+from datetime import datetime, timezone, tzinfo
+from typing import AsyncContextManager, Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +132,7 @@ def warn_deprecated_msg(warning_msg) -> None:
         category=DeprecationWarning,
         stacklevel=2,
     )
+    return None
 
 
 def get_local_timezone() -> Optional[tzinfo]:

--- a/yapapi/utils.py
+++ b/yapapi/utils.py
@@ -1,11 +1,11 @@
 """Utility functions and classes used within yapapi."""
 import asyncio
+from datetime import datetime, timezone, tzinfo
 import enum
 import functools
 import logging
-import warnings
-from datetime import datetime, timezone, tzinfo
 from typing import AsyncContextManager, Callable, Optional
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +132,6 @@ def warn_deprecated_msg(warning_msg) -> None:
         category=DeprecationWarning,
         stacklevel=2,
     )
-    return None
 
 
 def get_local_timezone() -> Optional[tzinfo]:


### PR DESCRIPTION
Resolves #986 

- [x] move logic to Service
- [x] remove `rest` warring and `pass` implemntations
- [x] improve `is_restart_required` method
- [x] check coverage and add tests if needed
- [x] remove old flags (`respawn_condition` and `respawn_unstarted_instances`)