### PR TITLE
Removed Network.owner_id because it was redundant

### DIFF
--- a/yapapi/engine.py
+++ b/yapapi/engine.py
@@ -1,4 +1,3 @@
-import aiohttp
 import asyncio
 from asyncio import CancelledError
 from collections import defaultdict
@@ -250,14 +249,6 @@ class _Engine:
 
         net_client = await stack.enter_async_context(self._api_config.net())
         self._net_api = rest.Net(net_client)
-
-        # TODO replace with a proper REST API client once ya-client and ya-aioclient are updated
-        # https://github.com/golemfactory/yapapi/issues/636
-        self._root_api_session = await stack.enter_async_context(
-            aiohttp.ClientSession(
-                headers=net_client.default_headers,
-            )
-        )
 
         self.payment_decorator = _Engine.PaymentDecorator(await self._create_allocations())
 

--- a/yapapi/golem.py
+++ b/yapapi/golem.py
@@ -1,7 +1,6 @@
 import asyncio
 from datetime import datetime, timedelta
 from decimal import Decimal
-import json
 import sys
 from typing import (
     TYPE_CHECKING,
@@ -486,13 +485,8 @@ class Golem:
         :param mask: Optional netmask (only if not provided within the `ip` argument)
         :param gateway: Optional gateway address for the network
         """
-        async with self._engine._root_api_session.get(
-            f"{self._engine._api_config.root_url}/me"
-        ) as resp:
-            identity = json.loads(await resp.text()).get("identity")
-
         return await Network.create(
-            self._engine._net_api, ip, identity, owner_ip, mask=mask, gateway=gateway
+            self._engine._net_api, ip, owner_ip, mask=mask, gateway=gateway
         )
 
     @staticmethod

--- a/yapapi/network.py
+++ b/yapapi/network.py
@@ -100,7 +100,6 @@ class Network:
         cls,
         net_api: "yapapi.rest.net.Net",
         ip: str,
-        owner_id: str,
         owner_ip: Optional[str] = None,
         mask: Optional[str] = None,
         gateway: Optional[str] = None,
@@ -109,13 +108,12 @@ class Network:
 
         :param net_api: the mid-level binding used directly to perform calls to the REST API.
         :param ip: the IP address of the network. May contain netmask, e.g. "192.168.0.0/24"
-        :param owner_id: the node ID of the owner of this VPN (the requestor)
         :param owner_ip: the desired IP address of the requestor node within the newly-created network
         :param mask: Optional netmask (only if not provided within the `ip` argument)
         :param gateway: Optional gateway address for the network
         """
 
-        network = cls(net_api, ip, owner_id, owner_ip, mask, gateway)
+        network = cls(net_api, ip, owner_ip, mask, gateway)
         network._state_machine.create()
 
         # create the network in yagna and set the id
@@ -134,7 +132,6 @@ class Network:
         self,
         net_api: "yapapi.rest.net.Net",
         ip: str,
-        owner_id: str,
         owner_ip: Optional[str] = None,
         mask: Optional[str] = None,
         gateway: Optional[str] = None,
@@ -142,7 +139,6 @@ class Network:
         """
         :param net_api: the mid-level binding used directly to perform calls to the REST API.
         :param ip: the IP address of the network. May contain netmask, e.g. "192.168.0.0/24"
-        :param owner_id: the node ID of the owner of this VPN (the requestor)
         :param owner_ip: the desired IP address of the requestor node within the newly-created network
         :param mask: Optional netmask (only if not provided within the `ip` argument)
         :param gateway: Optional gateway address for the network
@@ -158,7 +154,6 @@ class Network:
 
         self._network_id: Optional[str] = None
         self._gateway = gateway
-        self._owner_id = owner_id
         self._owner_ip: IpAddress = ip_address(owner_ip) if owner_ip else self._next_address()
         self._state_machine: NetworkState = NetworkState()
 
@@ -240,7 +235,6 @@ class Network:
 
         async with self._nodes_lock:
             self._ensure_ip_unique(ip)
-            self._nodes[self._owner_id] = Node(network=self, node_id=self._owner_id, ip=ip)
 
         await self._net_api.add_address(self.network_id, ip)
 


### PR DESCRIPTION
I removed everything related to `Network.owner_id` and `ssh.py` example works as before, so I assume it was just never needed.
I didn't fix the tests. Please proceed with this PR as you see fit :)