### PR TITLE
Update links resolving to the handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Golem application development
 
-For a detailed introduction to using Golem and yapapi to run your tasks on Golem and a guide to Golem Network application development in general, [please consult our handbook](https://handbook.golem.network/requestor-tutorials/flash-tutorial-of-requestor-development).
+For a detailed introduction to using Golem and yapapi to run your tasks on Golem and a guide to Golem Network application development in general, [please consult our docs](https://docs.golem.network/docs/quickstarts/python-quickstart).
 
 ### Installation
 
@@ -125,13 +125,12 @@ poetry run poe clean
 
 * [Golem](https://golem.network), a global, open-source, decentralized supercomputer that anyone can access.
 * Learn what you need to know to set-up your Golem requestor node:
-  * [Requestor development: a quick primer](https://handbook.golem.network/requestor-tutorials/flash-tutorial-of-requestor-development)
-  * [Run first task on Golem](https://handbook.golem.network/requestor-tutorials/flash-tutorial-of-requestor-development/run-first-task-on-golem)
-* Have a look at the most important concepts behind any Golem application: [Golem application fundamentals](https://handbook.golem.network/requestor-tutorials/golem-application-fundamentals)
-* Learn about preparing your own Docker-like images for the [VM runtime](https://handbook.golem.network/requestor-tutorials/vm-runtime)
+* [Requestor development: a quickstart](https://docs.golem.network/docs/quickstarts/python-quickstart)
+* Have a look at the most important concepts behind any Golem application: [Golem application fundamentals](https://docs.golem.network/docs/creators/python/guides/application-fundamentals)
+* Learn about preparing your own Docker-like images for the [VM runtime](https://docs.golem.network/docs/creators/python/examples/tools/converting-docker-image-to-golem-format)
 * Write your own app with yapapi:
-  * [Task Model development](https://handbook.golem.network/requestor-tutorials/task-processing-development)
-  * [Service Model development](https://handbook.golem.network/requestor-tutorials/service-development)
+  * [Task Model development](https://docs.golem.network/docs/creators/python/guides/task-model)
+  * [Service Model development](https://docs.golem.network/docs/creators/python/guides/service-model)
 
 ## Environment variables
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -6,6 +6,6 @@ Golem Python API Reference
 
     api
 
-    Golem Handbook <https://handbook.golem.network/>
+    Golem Docs <https://docs.golem.network/>
     Github <https://github.com/golemfactory/yapapi>
     Pypi <https://pypi.org/project/yapapi/>

--- a/examples/utils/__init__.py
+++ b/examples/utils/__init__.py
@@ -80,15 +80,12 @@ def run_golem_example(example_main, log_file=None):
     try:
         loop.run_until_complete(task)
     except NoPaymentAccountError as e:
-        handbook_url = (
-            "https://handbook.golem.network/requestor-tutorials/"
-            "flash-tutorial-of-requestor-development"
-        )
+        docs_url = "https://docs.golem.network/docs/creators/python/quickstarts/run-first-task-on-golem"
         print(
             f"{TEXT_COLOR_RED}"
             f"No payment account initialized for driver `{e.required_driver}` "
             f"and network `{e.required_network}`.\n\n"
-            f"See {handbook_url} on how to initialize payment accounts for a requestor node."
+            f"See {docs_url} on how to initialize payment accounts for a requestor node."
             f"{TEXT_COLOR_DEFAULT}"
         )
     except KeyboardInterrupt:

--- a/tests/drone/drone.py
+++ b/tests/drone/drone.py
@@ -119,15 +119,12 @@ if __name__ == "__main__":
     try:
         loop.run_until_complete(task)
     except NoPaymentAccountError as e:
-        handbook_url = (
-            "https://handbook.golem.network/requestor-tutorials/"
-            "flash-tutorial-of-requestor-development"
-        )
+        docs_url = "https://docs.golem.network/docs/creators/python/quickstarts/run-first-task-on-golem"
         print(
             f"{TEXT_COLOR_RED}"
             f"No payment account initialized for driver `{e.required_driver}` "
             f"and network `{e.required_network}`.\n\n"
-            f"See {handbook_url} on how to initialize payment accounts for a requestor node."
+            f"See {docs_url} on how to initialize payment accounts for a requestor node."
             f"{TEXT_COLOR_DEFAULT}"
         )
     except KeyboardInterrupt:

--- a/yapapi/payload/vm.py
+++ b/yapapi/payload/vm.py
@@ -100,7 +100,7 @@ async def manifest(
     Build a reference to application payload.
 
     :param manifest: base64 encoded Computation Payload Manifest
-        https://handbook.golem.network/requestor-tutorials/vm-runtime/computation-payload-manifest
+        https://docs.golem.network/docs/golem/payload-manifest#computation-payload-manifest
     :param manifest_sig: an optional signature of base64 encoded Computation Payload Manifest
     :param manifest_sig_algorithm: an optional signature algorithm, e.g. "sha256"
     :param manifest_cert: an optional base64 encoded public certificate (DER or PEM) matching key

--- a/yapapi/services/service.py
+++ b/yapapi/services/service.py
@@ -216,7 +216,7 @@ class Service:
         check the `Default implementation` section for more details.
 
         As a handler implementing the `work generator pattern
-        <https://handbook.golem.network/requestor-tutorials/golem-application-fundamentals/hl-api-work-generator-pattern>`_,
+        <https://docs.golem.network/docs/creators/python/guides/application-fundamentals#work-generator-pattern-and-work-context>`_,
         it's expected to be a generator that yields :class:`~yapapi.script.Script` (generated using
         the service's instance of the :class:`~yapapi.WorkContext` - :attr:`self._ctx`) that are
         then dispatched to the activity by the engine.
@@ -287,7 +287,7 @@ class Service:
         Should contain any operations needed to ensure continuous operation of a service.
 
         As a handler implementing the `work generator pattern
-        <https://handbook.golem.network/requestor-tutorials/golem-application-fundamentals/hl-api-work-generator-pattern>`_,
+        <https://docs.golem.network/docs/creators/python/guides/application-fundamentals#work-generator-pattern-and-work-context>`_,
         it's expected to be a generator that yields :class:`~yapapi.script.Script` (generated using
         the service's instance of the :class:`~yapapi.WorkContext` - :attr:`self._ctx`) that are
         then dispatched to the activity by the engine.
@@ -332,7 +332,7 @@ class Service:
         and gracefully shut-down - e.g. that its final state is retrieved.
 
         As a handler implementing the `work generator pattern
-        <https://handbook.golem.network/requestor-tutorials/golem-application-fundamentals/hl-api-work-generator-pattern>`_,
+        <https://docs.golem.network/docs/creators/python/guides/application-fundamentals#work-generator-pattern-and-work-context>`_,
         it's expected to be a generator that yields :class:`~yapapi.script.Script` (generated using
         the service's instance of the :class:`~yapapi.WorkContext` - :attr:`self._ctx`) that are
         then dispatched to the activity by the engine.


### PR DESCRIPTION
We made a switch from the handbook to the new docs and the links are broken right now. This should solve the issues.